### PR TITLE
ローカルで簡単に開発環境を立ち上げられるようカスタマイズしました

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -3,6 +3,9 @@ default: &default
   pool: <%= ENV["DB_POOL"] || ENV['MAX_THREADS'] || 5 %>
   timeout: 5000
   encoding: unicode
+  host: <%= ENV['DB_HOST'] || 'localhost' %>
+  port: <%= ENV['DB_PORT'] || 5432 %>
+  username: <%= ENV['DB_USER'] || 'postgres' %>
 
 development:
   <<: *default

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  db:
+    restart: always
+    image: postgres:alpine
+    ports:
+      - "5432:5432"
+
+  redis:
+    restart: always
+    image: redis:alpine
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
postgres と redis は docker で、rails は foreman で動きます。
開発環境の立ち上げはイカのコマンドから

```
$ docker-compose -f docker-compose.dev.yml up -d
$ foreman start
```

ただし初回のみ `docker-compose` のあと、下記コマンドの実行が必要になります。

```
$ bundle install --with development --path vendor/bundle
$ yarn install --pure-lockfile
$ bundle exec rails db:create
$ bundle exec rails db:schema:load
$ bundle exec rails db:seed
```