### PR TITLE
コードハイライト機能の追加

### DIFF
--- a/app/javascript/mastodon/actions/importer/normalizer.js
+++ b/app/javascript/mastodon/actions/importer/normalizer.js
@@ -1,5 +1,6 @@
 import escapeTextContentForBrowser from 'escape-html';
 import emojify from '../../features/emoji/emoji';
+import codeHighlight from '../../features/code_highlight';
 import { unescapeHTML } from '../../utils/html';
 
 const domParser = new DOMParser();
@@ -55,7 +56,7 @@ export function normalizeStatus(status, normalOldStatus) {
     const emojiMap      = makeEmojiMap(normalStatus);
 
     normalStatus.search_index = domParser.parseFromString(searchContent, 'text/html').documentElement.textContent;
-    normalStatus.contentHtml  = emojify(normalStatus.content, emojiMap);
+    normalStatus.contentHtml  = emojify(codeHighlight(normalStatus.content), emojiMap);
     normalStatus.spoilerHtml  = emojify(escapeTextContentForBrowser(spoilerText), emojiMap);
     normalStatus.hidden       = spoilerText.length > 0 || normalStatus.sensitive;
   }

--- a/app/javascript/mastodon/features/code_highlight/index.js
+++ b/app/javascript/mastodon/features/code_highlight/index.js
@@ -1,0 +1,30 @@
+import hljs from 'highlight.js';
+
+hljs.configure({
+  useBR: true,
+  tabReplace: '  ',
+});
+
+export default function highlightCode(text) {
+  try {
+    const doc = new DOMParser().parseFromString(text, 'text/html');
+
+    doc.querySelectorAll('code').forEach((el) => {
+      el.classList.add('hljs');
+      if (el.dataset.language && !el.dataset.highlighted) {
+        el.innerHTML = hljs.highlight(el.dataset.language, el.innerText).value;
+        el.dataset.highlighted = true;
+      }
+    });
+
+    let firstP = doc.querySelector('p');
+    if (firstP.innerHTML.length === 0) {
+      firstP.remove();
+    }
+
+    return doc.body.innerHTML;
+
+  } catch(e) {
+    return text;
+  }
+};

--- a/app/javascript/mastodon/utils/html.js
+++ b/app/javascript/mastodon/utils/html.js
@@ -1,6 +1,12 @@
 // NB: This function can still return unsafe HTML
 export const unescapeHTML = (html) => {
   const wrapper = document.createElement('div');
-  wrapper.innerHTML = html.replace(/<br\s*\/?>/g, '\n').replace(/<\/p><p>/g, '\n\n').replace(/<[^>]*>/g, '');
+  wrapper.innerHTML = html.replace(/<br\s*\/?>/g, '\n')
+    .replace(/<\/p><p>/g, '\n\n')
+    .replace(/<code class="singleline">(.+?)<\/code>/g, '`$1`\n') // singleline codeblock
+    .replace(/<code[^>]*data-language="(.+?)"[^>]*>/g, '```$1\n') // multiline codeblock with data-language
+    .replace(/<code[^>]*>/g, '```\n')                             // multiline codeblock
+    .replace(/<\/code>/g, '\n```')                                // multiline codeblock end tag
+    .replace(/<[^>]*>/g, '');
   return wrapper.textContent;
 };

--- a/app/javascript/styles/application.scss
+++ b/app/javascript/styles/application.scss
@@ -23,3 +23,5 @@
 @import 'mastodon/admin';
 @import 'mastodon/rtl';
 @import 'mastodon/accessibility';
+@import 'mastodon/code_highlight';
+@import '../../../node_modules/highlight.js/styles/solarized-dark';

--- a/app/javascript/styles/mastodon/code_highlight.scss
+++ b/app/javascript/styles/mastodon/code_highlight.scss
@@ -1,0 +1,3 @@
+code.hljs {
+  font-size: 90%;
+}

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "file-loader": "^0.11.2",
     "font-awesome": "^4.7.0",
     "glob": "^7.1.1",
+    "highlight.js": "^9.12.0",
     "http-link-header": "^0.8.0",
     "immutable": "^3.8.2",
     "imports-loader": "^0.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3299,6 +3299,10 @@ hawk@~6.0.2:
     hoek "4.x.x"
     sntp "2.x.x"
 
+highlight.js@^9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
+
 history@^4.7.2:
   version "4.7.2"
   resolved "https://registry.yarnpkg.com/history/-/history-4.7.2.tgz#22b5c7f31633c5b8021c7f4a8a954ac139ee8d5b"


### PR DESCRIPTION
# 記法

## single-line

```
`alert('hoge')`
```

## multi-line with language name

````
```javascript
var hoge = 'hoge'
alert(hoge)
```

```html
<div>
  <span>hoge</span>
</div>
```
````

## multi-line with NO language name

````
```
var hoge = 'hoge'
alert(hoge)
```

```
<div>
  <span>hoge</span>
</div>
```
````

# コードハイライトのスタイル

`app/javascript/styles/application.scss` で指定してます。
現状は自分の好みで solarized-dark にしてますがもしこだわりあればお好みで変更してください。

使用可能な style の一覧はこちらで確認できます。
https://highlightjs.org/static/demo/

<img width="334" alt="2018-07-24 18 20 35" src="https://user-images.githubusercontent.com/28823760/43129011-5cfc4e98-8f6e-11e8-9413-c4056e490c66.png">
