### PR TITLE
イカトドンのインフラ管理用ディレクトリ構造を追加

### DIFF
--- a/ikatodon/infra/database/README.md
+++ b/ikatodon/infra/database/README.md
@@ -1,0 +1,77 @@
+# イカトドン PostgreSQLサーバー構築
+
+このリポジトリには、イカトドンのPostgreSQLサーバーを構築するためのAnsibleプレイブックとTerraformコードが含まれています。
+
+## 概要
+
+このプロジェクトは、Mastodonインスタンス（イカトドン）のPostgreSQLサーバーを構築・管理するためのインフラストラクチャコードです。ConoHa VPSでの実行を前提としています。PostgreSQL 16を使用した新しいサーバーを構築し、既存のPostgreSQL 10からのデータ移行を容易にします。
+
+## 構成
+
+```
+mastodon/
+├── ikatodon/               # イカトドン独自の定義を管理するディレクトリ
+│   ├── infra/              # イカトドンのインフラを管理する
+│   │   ├── database/       # データベースサーバーのインフラを管理する
+│   │   │   ├── ansible/    # Ansibleコード
+│   │   │   │   ├── inventory/          # インベントリファイル
+│   │   │   │   ├── roles/              # ロール定義
+│   │   │   │   │   ├── common/         # 共通設定
+│   │   │   │   │   ├── postgresql/     # PostgreSQL設定
+│   │   │   │   │   ├── backup/         # バックアップ設定
+│   │   │   │   │   ├── mastodon/       # Mastodon連携設定
+│   │   │   │   │   └── monitoring/     # モニタリング設定
+│   │   │   │   ├── group_vars/         # グループ変数
+│   │   │   │   ├── host_vars/          # ホスト変数
+│   │   │   │   ├── playbooks/          # プレイブックファイル
+│   │   │   │   └── templates/          # テンプレートファイル
+│   │   │   └── terraform/              # Terraformコード
+│   │   │       ├── modules/            # モジュール
+│   │   │       └── environments/       # 環境設定
+```
+
+## 前提条件
+
+- Ansible 2.9以上
+- Terraform 1.0以上
+- ConoHa APIアクセス権限
+- SSH接続情報
+
+## 使用方法
+
+### 1. インフラストラクチャのプロビジョニング（Terraform）
+
+```bash
+cd mastodon/ikatodon/infra/database/terraform/environments/production
+terraform init
+terraform plan
+terraform apply
+```
+
+### 2. PostgreSQLサーバーの設定（Ansible）
+
+```bash
+cd mastodon/ikatodon/infra/database/ansible
+ansible-playbook -i inventory/production playbooks/postgresql-setup.yml
+```
+
+### 3. PostgreSQLアップグレード手順
+
+PostgreSQL 10から16へのアップグレード手順は、GitHubのIssueやGistに保存されています。以下のリンクを参照してください：
+
+- [PostgreSQL 10から16へのアップグレード手順](https://gist.github.com/koba-lab/upgrade-postgresql-10-to-16)
+- [アップグレード時のトラブルシューティング](https://gist.github.com/koba-lab/postgresql-upgrade-troubleshooting)
+
+※ 上記リンクは例示です。実際のGistリンクに置き換えてください。
+
+## カスタマイズ
+
+各環境に合わせて以下のファイルを編集してください：
+
+- `ansible/group_vars/all.yml` - 共通変数
+- `ansible/host_vars/` - ホスト固有の変数
+- `terraform/environments/production/terraform.tfvars` - Terraform変数
+
+## ライセンス
+
+MIT

--- a/ikatodon/infra/database/ansible/group_vars/all.yml
+++ b/ikatodon/infra/database/ansible/group_vars/all.yml
@@ -1,0 +1,42 @@
+---
+# 共通変数
+mastodon_user: mastodon
+mastodon_home: /home/mastodon
+mastodon_live_dir: '{{ mastodon_home }}/live'
+
+# PostgreSQL設定
+postgresql_version_old: 10
+postgresql_version_new: 16
+postgresql_data_dir_old: /var/lib/postgresql/{{ postgresql_version_old }}/main
+postgresql_data_dir_new: /var/lib/postgresql/{{ postgresql_version_new }}/main
+postgresql_conf_dir_old: /etc/postgresql/{{ postgresql_version_old }}/main
+postgresql_conf_dir_new: /etc/postgresql/{{ postgresql_version_new }}/main
+postgresql_bin_dir_old: /usr/lib/postgresql/{{ postgresql_version_old }}/bin
+postgresql_bin_dir_new: /usr/lib/postgresql/{{ postgresql_version_new }}/bin
+postgresql_service_old: postgresql@{{ postgresql_version_old }}-main
+postgresql_service_new: postgresql@{{ postgresql_version_new }}-main
+
+# データベース設定
+db_name: mastodon_production
+db_user: mastodon
+db_password: '{{ vault_db_password }}'
+db_host: "{{ hostvars[groups['postgresql_servers'][0]]['private_ip'] }}"
+db_port: 5432
+
+# バックアップ設定
+backup_dir: /var/backups/postgresql
+backup_retention: 7
+backup_filename: '{{ db_name }}_{{ ansible_date_time.date }}.dump'
+
+# アップグレード設定
+max_downtime_minutes: 10
+maintenance_mode: true
+upgrade_method: pg_upgrade # pg_upgrade, logical_replication, or dump_restore
+
+# モニタリング設定
+monitoring_enabled: true
+prometheus_node_exporter_enabled: true
+postgres_exporter_enabled: true
+
+# ネットワーク設定
+private_network_cidr: 192.168.0.0/24

--- a/ikatodon/infra/database/ansible/host_vars/pg01.yml
+++ b/ikatodon/infra/database/ansible/host_vars/pg01.yml
@@ -1,0 +1,18 @@
+---
+# 現在のPostgreSQLサーバー固有の変数
+ansible_host: "{{ lookup('env', 'PG_OLD_IP') | default('192.168.0.5', true) }}"
+private_ip: "{{ lookup('env', 'PG_OLD_PRIVATE_IP') | default('192.168.0.5', true) }}"
+
+# PostgreSQL設定
+postgresql_version: '{{ postgresql_version_old }}'
+postgresql_data_dir: '{{ postgresql_data_dir_old }}'
+postgresql_conf_dir: '{{ postgresql_conf_dir_old }}'
+postgresql_bin_dir: '{{ postgresql_bin_dir_old }}'
+postgresql_service: '{{ postgresql_service_old }}'
+
+# リソース設定
+postgresql_max_connections: 100
+postgresql_shared_buffers_percent: 25
+postgresql_work_mem: '4MB'
+postgresql_maintenance_work_mem_percent: 5
+postgresql_effective_cache_size_percent: 50

--- a/ikatodon/infra/database/ansible/host_vars/pg_new.yml
+++ b/ikatodon/infra/database/ansible/host_vars/pg_new.yml
@@ -1,0 +1,18 @@
+---
+# 新PostgreSQLサーバー固有の変数
+ansible_host: "{{ lookup('env', 'PG_NEW_IP') | default('192.168.0.10', true) }}"
+private_ip: "{{ lookup('env', 'PG_NEW_PRIVATE_IP') | default('192.168.0.10', true) }}"
+
+# PostgreSQL設定
+postgresql_version: '{{ postgresql_version_new }}'
+postgresql_data_dir: '{{ postgresql_data_dir_new }}'
+postgresql_conf_dir: '{{ postgresql_conf_dir_new }}'
+postgresql_bin_dir: '{{ postgresql_bin_dir_new }}'
+postgresql_service: '{{ postgresql_service_new }}'
+
+# リソース設定
+postgresql_max_connections: 200
+postgresql_shared_buffers_percent: 25
+postgresql_work_mem: '8MB'
+postgresql_maintenance_work_mem_percent: 5
+postgresql_effective_cache_size_percent: 50

--- a/ikatodon/infra/database/ansible/inventory/production
+++ b/ikatodon/infra/database/ansible/inventory/production
@@ -1,0 +1,27 @@
+# PostgreSQL サーバー
+[postgresql_servers]
+pg01 ansible_host=<PostgreSQLサーバーのIPアドレス> private_ip=<プライベートIPアドレス>
+
+# Webサーバー
+[web_servers]
+web01 ansible_host=<Webサーバー1のIPアドレス> private_ip=<プライベートIPアドレス>
+web02 ansible_host=<Webサーバー2のIPアドレス> private_ip=<プライベートIPアドレス>
+
+# Redisサーバー
+[redis_servers]
+redis01 ansible_host=<RedisサーバーのIPアドレス> private_ip=<プライベートIPアドレス>
+
+# 新しいPostgreSQLサーバー（アップグレード用）
+[new_postgresql_servers]
+pg_new ansible_host=<新PostgreSQLサーバーのIPアドレス> private_ip=<プライベートIPアドレス>
+
+# グループ定義
+[mastodon:children]
+web_servers
+postgresql_servers
+redis_servers
+
+[all:vars]
+ansible_user=mastodon
+ansible_ssh_private_key_file=~/.ssh/id_rsa
+ansible_python_interpreter=/usr/bin/python3

--- a/ikatodon/infra/database/ansible/roles/backup/tasks/main.yml
+++ b/ikatodon/infra/database/ansible/roles/backup/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+# バックアップタスク
+- name: バックアップディレクトリの作成
+  file:
+    path: '{{ backup_dir }}'
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: 0700
+
+- name: バックアップスクリプトの作成
+  template:
+    src: backup_postgresql.sh.j2
+    dest: /usr/local/bin/backup_postgresql.sh
+    owner: root
+    group: root
+    mode: 0755
+
+- name: cronジョブの設定
+  cron:
+    name: 'PostgreSQLバックアップ'
+    user: postgres
+    job: '/usr/local/bin/backup_postgresql.sh'
+    hour: '1'
+    minute: '0'
+    state: present
+
+- name: バックアップローテーションスクリプトの作成
+  template:
+    src: rotate_backups.sh.j2
+    dest: /usr/local/bin/rotate_backups.sh
+    owner: root
+    group: root
+    mode: 0755
+
+- name: バックアップローテーションのcronジョブ設定
+  cron:
+    name: 'PostgreSQLバックアップローテーション'
+    user: root
+    job: '/usr/local/bin/rotate_backups.sh'
+    hour: '2'
+    minute: '0'
+    state: present

--- a/ikatodon/infra/database/ansible/roles/backup/templates/backup_postgresql.sh.j2
+++ b/ikatodon/infra/database/ansible/roles/backup/templates/backup_postgresql.sh.j2
@@ -1,0 +1,34 @@
+#!/bin/bash
+# PostgreSQLバックアップスクリプト
+# {{ ansible_managed }}
+
+# 変数
+BACKUP_DIR="{{ backup_dir }}"
+DB_NAME="{{ db_name }}"
+DATE=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="${BACKUP_DIR}/${DB_NAME}_${DATE}.dump"
+LOG_FILE="${BACKUP_DIR}/backup_${DATE}.log"
+
+# バックアップディレクトリの確認
+if [ ! -d "$BACKUP_DIR" ]; then
+  mkdir -p "$BACKUP_DIR"
+  chown postgres:postgres "$BACKUP_DIR"
+  chmod 700 "$BACKUP_DIR"
+fi
+
+# バックアップの実行
+echo "PostgreSQLバックアップ開始: $(date)" > "$LOG_FILE"
+pg_dump -Fc -U postgres "$DB_NAME" > "$BACKUP_FILE" 2>> "$LOG_FILE"
+
+# 結果の確認
+if [ $? -eq 0 ]; then
+  echo "バックアップ成功: $BACKUP_FILE" >> "$LOG_FILE"
+  # バックアップファイルの権限設定
+  chmod 600 "$BACKUP_FILE"
+else
+  echo "バックアップ失敗" >> "$LOG_FILE"
+  exit 1
+fi
+
+echo "PostgreSQLバックアップ完了: $(date)" >> "$LOG_FILE"
+exit 0

--- a/ikatodon/infra/database/ansible/roles/backup/templates/rotate_backups.sh.j2
+++ b/ikatodon/infra/database/ansible/roles/backup/templates/rotate_backups.sh.j2
@@ -1,0 +1,14 @@
+#!/bin/bash
+# PostgreSQLバックアップローテーションスクリプト
+# {{ ansible_managed }}
+
+# 変数
+BACKUP_DIR="{{ backup_dir }}"
+RETENTION_DAYS="{{ backup_retention }}"
+
+# 古いバックアップファイルの削除
+find "$BACKUP_DIR" -name "*.dump" -type f -mtime +$RETENTION_DAYS -delete
+find "$BACKUP_DIR" -name "backup_*.log" -type f -mtime +$RETENTION_DAYS -delete
+
+echo "$(date): $RETENTION_DAYS日以上経過したバックアップファイルを削除しました。" >> "$BACKUP_DIR/rotation.log"
+exit 0

--- a/ikatodon/infra/database/ansible/roles/common/handlers/main.yml
+++ b/ikatodon/infra/database/ansible/roles/common/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+# 共通ハンドラー
+- name: restart ssh
+  systemd:
+    name: sshd
+    state: restarted
+
+- name: reload sysctl
+  shell: sysctl -p

--- a/ikatodon/infra/database/ansible/roles/common/tasks/main.yml
+++ b/ikatodon/infra/database/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,84 @@
+---
+# 共通タスク
+- name: システムパッケージの更新
+  apt:
+    update_cache: yes
+    cache_valid_time: 3600
+
+- name: 必要なパッケージのインストール
+  apt:
+    name:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+      - python3
+      - python3-pip
+      - python3-psycopg2
+      - htop
+      - iotop
+      - sysstat
+      - net-tools
+      - vim
+      - tmux
+      - rsync
+      - ufw
+    state: present
+
+- name: タイムゾーンの設定
+  timezone:
+    name: Asia/Tokyo
+
+- name: ホスト名の設定
+  hostname:
+    name: '{{ inventory_hostname }}'
+
+- name: ファイアウォールの設定
+  ufw:
+    rule: allow
+    port: '{{ item }}'
+    proto: tcp
+  loop:
+    - 22
+    - 80
+    - 443
+    - 5432
+  when: inventory_hostname in groups['postgresql_servers'] or inventory_hostname in groups['new_postgresql_servers']
+
+- name: ファイアウォールの有効化
+  ufw:
+    state: enabled
+    policy: deny
+
+- name: スワップ設定の最適化
+  sysctl:
+    name: '{{ item.key }}'
+    value: '{{ item.value }}'
+    state: present
+    reload: yes
+  loop:
+    - { key: 'vm.swappiness', value: '10' }
+    - { key: 'vm.dirty_ratio', value: '80' }
+    - { key: 'vm.dirty_background_ratio', value: '5' }
+
+- name: システムリミットの設定
+  pam_limits:
+    domain: '*'
+    limit_type: '{{ item.type }}'
+    limit_item: '{{ item.item }}'
+    value: '{{ item.value }}'
+  loop:
+    - { type: 'soft', item: 'nofile', value: '65536' }
+    - { type: 'hard', item: 'nofile', value: '65536' }
+    - { type: 'soft', item: 'nproc', value: '65536' }
+    - { type: 'hard', item: 'nproc', value: '65536' }
+
+- name: SSHの設定
+  template:
+    src: sshd_config.j2
+    dest: /etc/ssh/sshd_config
+    owner: root
+    group: root
+    mode: 0644
+  notify: restart ssh

--- a/ikatodon/infra/database/ansible/roles/common/templates/sshd_config.j2
+++ b/ikatodon/infra/database/ansible/roles/common/templates/sshd_config.j2
@@ -1,0 +1,30 @@
+# SSHサーバー設定
+# {{ ansible_managed }}
+
+Port 22
+Protocol 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# ログイン設定
+LoginGraceTime 120
+PermitRootLogin prohibit-password
+StrictModes yes
+MaxAuthTries 6
+MaxSessions 10
+
+# 認証設定
+PubkeyAuthentication yes
+PasswordAuthentication yes
+PermitEmptyPasswords no
+ChallengeResponseAuthentication no
+UsePAM yes
+
+# その他設定
+X11Forwarding yes
+PrintMotd no
+AcceptEnv LANG LC_*
+Subsystem sftp /usr/lib/openssh/sftp-server
+ClientAliveInterval 120
+ClientAliveCountMax 3

--- a/ikatodon/infra/database/ansible/roles/mastodon/tasks/main.yml
+++ b/ikatodon/infra/database/ansible/roles/mastodon/tasks/main.yml
@@ -1,0 +1,46 @@
+---
+# Mastodonアプリケーション連携タスク
+- name: Mastodonユーザーの存在確認
+  user:
+    name: '{{ mastodon_user }}'
+    state: present
+    shell: /bin/bash
+    home: '{{ mastodon_home }}'
+  check_mode: yes
+  register: mastodon_user_check
+  failed_when: false
+
+- name: Mastodonディレクトリの存在確認
+  stat:
+    path: '{{ mastodon_live_dir }}'
+  register: mastodon_dir_check
+
+- name: Mastodonの.env.productionファイルの存在確認
+  stat:
+    path: '{{ mastodon_live_dir }}/.env.production'
+  register: env_file_check
+  when: mastodon_dir_check.stat.exists
+
+- name: データベース接続設定の更新
+  lineinfile:
+    path: '{{ mastodon_live_dir }}/.env.production'
+    regexp: '^DB_HOST='
+    line: "DB_HOST={{ hostvars[groups['new_postgresql_servers'][0]]['private_ip'] }}"
+  when: env_file_check.stat.exists | default(false)
+
+- name: データベースポート設定の更新
+  lineinfile:
+    path: '{{ mastodon_live_dir }}/.env.production'
+    regexp: '^DB_PORT='
+    line: 'DB_PORT=5432'
+  when: env_file_check.stat.exists | default(false)
+
+- name: Mastodonサービスの再起動
+  systemd:
+    name: '{{ item }}'
+    state: restarted
+  loop:
+    - mastodon-web
+    - mastodon-sidekiq
+    - mastodon-streaming
+  when: env_file_check.stat.exists | default(false)

--- a/ikatodon/infra/database/ansible/roles/monitoring/handlers/main.yml
+++ b/ikatodon/infra/database/ansible/roles/monitoring/handlers/main.yml
@@ -1,0 +1,11 @@
+---
+# モニタリングハンドラー
+- name: restart postgres_exporter
+  systemd:
+    name: prometheus-postgres-exporter
+    state: restarted
+
+- name: restart node_exporter
+  systemd:
+    name: prometheus-node-exporter
+    state: restarted

--- a/ikatodon/infra/database/ansible/roles/monitoring/tasks/main.yml
+++ b/ikatodon/infra/database/ansible/roles/monitoring/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+# モニタリングタスク
+- name: Prometheusリポジトリの追加
+  apt_repository:
+    repo: 'deb https://packagecloud.io/prometheus-rpm/release/ubuntu/ {{ ansible_distribution_release }} main'
+    state: present
+    filename: prometheus
+  when: prometheus_node_exporter_enabled | bool
+
+- name: Prometheusリポジトリキーの追加
+  apt_key:
+    url: https://packagecloud.io/prometheus-rpm/release/gpgkey
+    state: present
+  when: prometheus_node_exporter_enabled | bool
+
+- name: Node Exporterのインストール
+  apt:
+    name: prometheus-node-exporter
+    state: present
+    update_cache: yes
+  when: prometheus_node_exporter_enabled | bool
+
+- name: Node Exporterサービスの有効化と起動
+  systemd:
+    name: prometheus-node-exporter
+    enabled: yes
+    state: started
+  when: prometheus_node_exporter_enabled | bool
+
+- name: PostgreSQL Exporterのインストール
+  apt:
+    name: prometheus-postgres-exporter
+    state: present
+  when: postgres_exporter_enabled | bool and (inventory_hostname in groups['postgresql_servers'] or inventory_hostname in groups['new_postgresql_servers'])
+
+- name: PostgreSQL Exporter設定ファイルの作成
+  template:
+    src: postgres_exporter.yml.j2
+    dest: /etc/prometheus-postgres-exporter/postgres_exporter.yml
+    owner: postgres
+    group: postgres
+    mode: 0600
+  when: postgres_exporter_enabled | bool and (inventory_hostname in groups['postgresql_servers'] or inventory_hostname in groups['new_postgresql_servers'])
+  notify: restart postgres_exporter
+
+- name: PostgreSQL Exporterサービスの有効化と起動
+  systemd:
+    name: prometheus-postgres-exporter
+    enabled: yes
+    state: started
+  when: postgres_exporter_enabled | bool and (inventory_hostname in groups['postgresql_servers'] or inventory_hostname in groups['new_postgresql_servers'])
+
+- name: モニタリングスクリプトの作成
+  template:
+    src: monitor_postgresql.sh.j2
+    dest: /usr/local/bin/monitor_postgresql.sh
+    owner: root
+    group: root
+    mode: 0755
+  when: inventory_hostname in groups['postgresql_servers'] or inventory_hostname in groups['new_postgresql_servers']
+
+- name: モニタリングcronジョブの設定
+  cron:
+    name: 'PostgreSQLモニタリング'
+    user: root
+    job: '/usr/local/bin/monitor_postgresql.sh'
+    minute: '*/5'
+    state: present
+  when: inventory_hostname in groups['postgresql_servers'] or inventory_hostname in groups['new_postgresql_servers']

--- a/ikatodon/infra/database/ansible/roles/monitoring/templates/monitor_postgresql.sh.j2
+++ b/ikatodon/infra/database/ansible/roles/monitoring/templates/monitor_postgresql.sh.j2
@@ -1,0 +1,78 @@
+#!/bin/bash
+# PostgreSQLモニタリングスクリプト
+# {{ ansible_managed }}
+
+# 変数
+LOG_DIR="/var/log/postgresql-monitor"
+DATE=$(date +%Y%m%d_%H%M%S)
+LOG_FILE="${LOG_DIR}/monitor_${DATE}.log"
+ALERT_THRESHOLD_CONNECTIONS=100
+ALERT_THRESHOLD_DISK_USAGE=80
+ALERT_THRESHOLD_CPU_USAGE=90
+ALERT_THRESHOLD_MEMORY_USAGE=90
+
+# ログディレクトリの確認
+if [ ! -d "$LOG_DIR" ]; then
+  mkdir -p "$LOG_DIR"
+  chmod 755 "$LOG_DIR"
+fi
+
+# ヘッダー
+echo "PostgreSQLモニタリングレポート - $(date)" > "$LOG_FILE"
+echo "----------------------------------------" >> "$LOG_FILE"
+
+# システムリソース
+echo "## システムリソース" >> "$LOG_FILE"
+echo "CPU使用率: $(top -bn1 | grep "Cpu(s)" | awk '{print $2 + $4}')%" >> "$LOG_FILE"
+echo "メモリ使用率: $(free -m | awk 'NR==2{printf "%.2f%%", $3*100/$2}')%" >> "$LOG_FILE"
+echo "ディスク使用率: $(df -h / | awk 'NR==2{print $5}')%" >> "$LOG_FILE"
+echo "ロード平均: $(uptime | awk -F'load average:' '{print $2}')" >> "$LOG_FILE"
+echo "" >> "$LOG_FILE"
+
+# PostgreSQL接続数
+echo "## PostgreSQL接続数" >> "$LOG_FILE"
+su - postgres -c "psql -c 'SELECT count(*) AS connections FROM pg_stat_activity;'" >> "$LOG_FILE" 2>&1
+echo "" >> "$LOG_FILE"
+
+# データベースサイズ
+echo "## データベースサイズ" >> "$LOG_FILE"
+su - postgres -c "psql -c 'SELECT pg_database.datname, pg_size_pretty(pg_database_size(pg_database.datname)) AS size FROM pg_database ORDER BY pg_database_size(pg_database.datname) DESC;'" >> "$LOG_FILE" 2>&1
+echo "" >> "$LOG_FILE"
+
+# テーブルサイズ
+echo "## 最大テーブルサイズ（上位5件）" >> "$LOG_FILE"
+su - postgres -c "psql -d {{ db_name }} -c \"SELECT table_schema, table_name, pg_size_pretty(pg_total_relation_size(table_schema || '.' || table_name)) AS total_size FROM information_schema.tables WHERE table_schema NOT IN ('pg_catalog', 'information_schema') ORDER BY pg_total_relation_size(table_schema || '.' || table_name) DESC LIMIT 5;\"" >> "$LOG_FILE" 2>&1
+echo "" >> "$LOG_FILE"
+
+# スロークエリ
+echo "## スロークエリ（直近10件）" >> "$LOG_FILE"
+su - postgres -c "psql -d {{ db_name }} -c \"SELECT query, calls, total_time, mean_time, max_time FROM pg_stat_statements ORDER BY total_time DESC LIMIT 10;\"" >> "$LOG_FILE" 2>&1
+echo "" >> "$LOG_FILE"
+
+# アラート
+echo "## アラート" >> "$LOG_FILE"
+CONNECTIONS=$(su - postgres -c "psql -t -c 'SELECT count(*) FROM pg_stat_activity;'" | tr -d ' ')
+DISK_USAGE=$(df -h / | awk 'NR==2{print $5}' | tr -d '%')
+CPU_USAGE=$(top -bn1 | grep "Cpu(s)" | awk '{print $2 + $4}')
+MEMORY_USAGE=$(free -m | awk 'NR==2{printf "%.0f", $3*100/$2}')
+
+if [ "$CONNECTIONS" -gt "$ALERT_THRESHOLD_CONNECTIONS" ]; then
+  echo "警告: 接続数が閾値を超えています ($CONNECTIONS > $ALERT_THRESHOLD_CONNECTIONS)" >> "$LOG_FILE"
+fi
+
+if [ "$DISK_USAGE" -gt "$ALERT_THRESHOLD_DISK_USAGE" ]; then
+  echo "警告: ディスク使用率が閾値を超えています ($DISK_USAGE% > $ALERT_THRESHOLD_DISK_USAGE%)" >> "$LOG_FILE"
+fi
+
+if [ "$CPU_USAGE" -gt "$ALERT_THRESHOLD_CPU_USAGE" ]; then
+  echo "警告: CPU使用率が閾値を超えています ($CPU_USAGE% > $ALERT_THRESHOLD_CPU_USAGE%)" >> "$LOG_FILE"
+fi
+
+if [ "$MEMORY_USAGE" -gt "$ALERT_THRESHOLD_MEMORY_USAGE" ]; then
+  echo "警告: メモリ使用率が閾値を超えています ($MEMORY_USAGE% > $ALERT_THRESHOLD_MEMORY_USAGE%)" >> "$LOG_FILE"
+fi
+
+# ログローテーション（30日以上経過したログを削除）
+find "$LOG_DIR" -name "monitor_*.log" -type f -mtime +30 -delete
+
+exit 0

--- a/ikatodon/infra/database/ansible/roles/monitoring/templates/postgres_exporter.yml.j2
+++ b/ikatodon/infra/database/ansible/roles/monitoring/templates/postgres_exporter.yml.j2
@@ -1,0 +1,50 @@
+# PostgreSQL Exporter設定
+# {{ ansible_managed }}
+
+DATA_SOURCE_NAME: "postgresql://{{ db_user }}:{{ db_password }}@localhost:5432/{{ db_name }}?sslmode=disable"
+
+# クエリ設定
+queries:
+  - name: "pg_stat_activity"
+    query: "SELECT count(*) as count, state FROM pg_stat_activity GROUP BY state"
+    metrics:
+      - count:
+          usage: "GAUGE"
+          description: "Number of connections in this state"
+      - state:
+          usage: "LABEL"
+          description: "Connection state"
+
+  - name: "pg_stat_database"
+    query: "SELECT datname, xact_commit, xact_rollback, blks_read, blks_hit, tup_returned, tup_fetched, tup_inserted, tup_updated, tup_deleted FROM pg_stat_database WHERE datname != 'template0' AND datname != 'template1'"
+    metrics:
+      - datname:
+          usage: "LABEL"
+          description: "Database name"
+      - xact_commit:
+          usage: "COUNTER"
+          description: "Number of transactions committed"
+      - xact_rollback:
+          usage: "COUNTER"
+          description: "Number of transactions rolled back"
+      - blks_read:
+          usage: "COUNTER"
+          description: "Number of disk blocks read"
+      - blks_hit:
+          usage: "COUNTER"
+          description: "Number of buffer hits"
+      - tup_returned:
+          usage: "COUNTER"
+          description: "Number of rows returned"
+      - tup_fetched:
+          usage: "COUNTER"
+          description: "Number of rows fetched"
+      - tup_inserted:
+          usage: "COUNTER"
+          description: "Number of rows inserted"
+      - tup_updated:
+          usage: "COUNTER"
+          description: "Number of rows updated"
+      - tup_deleted:
+          usage: "COUNTER"
+          description: "Number of rows deleted"

--- a/ikatodon/infra/database/ansible/roles/postgresql/handlers/main.yml
+++ b/ikatodon/infra/database/ansible/roles/postgresql/handlers/main.yml
@@ -1,0 +1,17 @@
+---
+# PostgreSQLハンドラー
+- name: restart postgresql
+  systemd:
+    name: 'postgresql@{{ postgresql_version }}-main'
+    state: restarted
+
+- name: restart postgresql old
+  systemd:
+    name: '{{ postgresql_service_old }}'
+    state: restarted
+  delegate_to: "{{ groups['postgresql_servers'][0] }}"
+
+- name: restart postgresql new
+  systemd:
+    name: '{{ postgresql_service_new }}'
+    state: restarted

--- a/ikatodon/infra/database/ansible/roles/postgresql/tasks/main.yml
+++ b/ikatodon/infra/database/ansible/roles/postgresql/tasks/main.yml
@@ -1,0 +1,62 @@
+---
+# PostgreSQLのインストールと設定
+- name: PostgreSQLリポジトリの追加
+  apt_repository:
+    repo: 'deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main'
+    state: present
+    filename: pgdg
+
+- name: PostgreSQLリポジトリキーの追加
+  apt_key:
+    url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+    state: present
+
+- name: パッケージリストの更新
+  apt:
+    update_cache: yes
+
+- name: PostgreSQL {{ postgresql_version }} のインストール
+  apt:
+    name:
+      - postgresql-{{ postgresql_version }}
+      - postgresql-client-{{ postgresql_version }}
+      - postgresql-contrib-{{ postgresql_version }}
+      - libpq-dev
+      - python3-psycopg2
+    state: present
+
+- name: PostgreSQLサービスの有効化と起動
+  systemd:
+    name: 'postgresql@{{ postgresql_version }}-main'
+    enabled: yes
+    state: started
+
+- name: PostgreSQL設定ファイルのバックアップ
+  copy:
+    src: '{{ postgresql_conf_dir }}/{{ item }}'
+    dest: '{{ postgresql_conf_dir }}/{{ item }}.bak'
+    remote_src: yes
+  loop:
+    - postgresql.conf
+    - pg_hba.conf
+  when: ansible_check_mode == false
+
+- name: PostgreSQL設定ファイルの更新
+  template:
+    src: '{{ item }}.j2'
+    dest: '{{ postgresql_conf_dir }}/{{ item }}'
+    owner: postgres
+    group: postgres
+    mode: 0644
+  loop:
+    - postgresql.conf
+    - pg_hba.conf
+  notify: restart postgresql
+
+- name: pg_stat_statementsの有効化
+  lineinfile:
+    path: '{{ postgresql_conf_dir }}/postgresql.conf'
+    line: "shared_preload_libraries = 'pg_stat_statements'"
+    regexp: '^shared_preload_libraries'
+    state: present
+  notify: restart postgresql

--- a/ikatodon/infra/database/ansible/roles/postgresql/tasks/upgrade_dump_restore.yml
+++ b/ikatodon/infra/database/ansible/roles/postgresql/tasks/upgrade_dump_restore.yml
@@ -1,0 +1,50 @@
+---
+# ダンプ/リストアを使用したPostgreSQLアップグレード
+- name: バックアップディレクトリの作成
+  file:
+    path: '{{ backup_dir }}'
+    state: directory
+    owner: postgres
+    group: postgres
+    mode: 0700
+
+- name: データベースのダンプ作成
+  become: true
+  become_user: postgres
+  shell: |
+    pg_dump -Fc -U postgres {{ db_name }} > {{ backup_dir }}/{{ backup_filename }}
+  delegate_to: "{{ groups['postgresql_servers'][0] }}"
+  args:
+    creates: '{{ backup_dir }}/{{ backup_filename }}'
+
+- name: バックアップファイルの転送
+  synchronize:
+    src: '{{ backup_dir }}/{{ backup_filename }}'
+    dest: '{{ backup_dir }}/{{ backup_filename }}'
+    mode: pull
+  delegate_to: "{{ groups['postgresql_servers'][0] }}"
+
+- name: 新しいPostgreSQLでデータベースとユーザーの作成
+  become: true
+  become_user: postgres
+  shell: |
+    dropdb --if-exists {{ db_name }}
+    createdb -T template0 {{ db_name }}
+    psql -c "CREATE USER {{ db_user }} WITH PASSWORD '{{ db_password }}';" postgres
+    psql -c "ALTER USER {{ db_user }} WITH SUPERUSER;" postgres
+  register: create_db
+  failed_when: create_db.rc != 0 and "already exists" not in create_db.stderr
+
+- name: データベースのリストア
+  become: true
+  become_user: postgres
+  shell: |
+    pg_restore -U postgres -d {{ db_name }} --no-owner --role={{ db_user }} {{ backup_dir }}/{{ backup_filename }}
+  register: restore_result
+  failed_when: restore_result.rc > 1
+
+- name: スーパーユーザー権限の削除
+  become: true
+  become_user: postgres
+  shell: |
+    psql -c "ALTER USER {{ db_user }} WITH NOSUPERUSER;" postgres

--- a/ikatodon/infra/database/ansible/roles/postgresql/tasks/upgrade_logical_replication.yml
+++ b/ikatodon/infra/database/ansible/roles/postgresql/tasks/upgrade_logical_replication.yml
@@ -1,0 +1,58 @@
+---
+# 論理レプリケーションを使用したPostgreSQLアップグレード
+- name: 古いPostgreSQLの設定更新（レプリケーション用）
+  lineinfile:
+    path: '{{ postgresql_conf_dir_old }}/postgresql.conf'
+    regexp: '^{{ item.key }}'
+    line: '{{ item.key }} = {{ item.value }}'
+    state: present
+  loop:
+    - { key: 'wal_level', value: 'logical' }
+    - { key: 'max_wal_senders', value: '10' }
+    - { key: 'max_replication_slots', value: '10' }
+  delegate_to: "{{ groups['postgresql_servers'][0] }}"
+  notify: restart postgresql old
+
+- name: レプリケーション用のpg_hba.conf設定
+  lineinfile:
+    path: '{{ postgresql_conf_dir_old }}/pg_hba.conf'
+    line: "host replication {{ db_user }} {{ hostvars[groups['new_postgresql_servers'][0]]['private_ip'] }}/32 md5"
+    state: present
+  delegate_to: "{{ groups['postgresql_servers'][0] }}"
+  notify: restart postgresql old
+
+- name: パブリケーションの作成
+  become: true
+  become_user: postgres
+  shell: |
+    psql -c "CREATE PUBLICATION mastodon_pub FOR ALL TABLES;" {{ db_name }}
+  delegate_to: "{{ groups['postgresql_servers'][0] }}"
+  register: create_publication
+  failed_when: create_publication.rc != 0 and "already exists" not in create_publication.stderr
+
+- name: 新しいPostgreSQLでデータベースとユーザーの作成
+  become: true
+  become_user: postgres
+  shell: |
+    psql -c "CREATE USER {{ db_user }} WITH PASSWORD '{{ db_password }}';"
+    psql -c "CREATE DATABASE {{ db_name }} OWNER {{ db_user }};"
+  register: create_db
+  failed_when: create_db.rc != 0 and "already exists" not in create_db.stderr
+
+- name: サブスクリプションの作成
+  become: true
+  become_user: postgres
+  shell: |
+    psql -c "CREATE SUBSCRIPTION mastodon_sub CONNECTION 'host={{ hostvars[groups['postgresql_servers'][0]]['private_ip'] }} dbname={{ db_name }} user={{ db_user }} password={{ db_password }}' PUBLICATION mastodon_pub;" {{ db_name }}
+  register: create_subscription
+  failed_when: create_subscription.rc != 0 and "already exists" not in create_subscription.stderr
+
+- name: レプリケーションの進行状況を確認
+  become: true
+  become_user: postgres
+  shell: |
+    psql -c "SELECT * FROM pg_stat_subscription;" {{ db_name }}
+  register: replication_status
+  until: replication_status.stdout.find("0 0 0") != -1
+  retries: 60
+  delay: 10

--- a/ikatodon/infra/database/ansible/roles/postgresql/tasks/upgrade_pg_upgrade.yml
+++ b/ikatodon/infra/database/ansible/roles/postgresql/tasks/upgrade_pg_upgrade.yml
@@ -1,0 +1,50 @@
+---
+# pg_upgradeを使用したPostgreSQLアップグレード
+- name: 古いPostgreSQLサービスの停止
+  systemd:
+    name: '{{ postgresql_service_old }}'
+    state: stopped
+  delegate_to: "{{ groups['postgresql_servers'][0] }}"
+
+- name: 新しいPostgreSQLサービスの停止
+  systemd:
+    name: '{{ postgresql_service_new }}'
+    state: stopped
+
+- name: pg_upgradeの実行
+  become: true
+  become_user: postgres
+  shell: |
+    {{ postgresql_bin_dir_new }}/pg_upgrade \
+    --old-datadir={{ postgresql_data_dir_old }} \
+    --new-datadir={{ postgresql_data_dir_new }} \
+    --old-bindir={{ postgresql_bin_dir_old }} \
+    --new-bindir={{ postgresql_bin_dir_new }} \
+    --old-options "-c config_file={{ postgresql_conf_dir_old }}/postgresql.conf" \
+    --new-options "-c config_file={{ postgresql_conf_dir_new }}/postgresql.conf" \
+    --link
+  args:
+    chdir: /tmp
+    creates: '{{ postgresql_data_dir_new }}/PG_VERSION'
+
+- name: 新しいPostgreSQLサービスの起動
+  systemd:
+    name: '{{ postgresql_service_new }}'
+    state: started
+    enabled: yes
+
+- name: 最適化スクリプトの実行
+  become: true
+  become_user: postgres
+  shell: ./analyze_new_cluster.sh
+  args:
+    chdir: /tmp
+    creates: /tmp/analyze_new_cluster.log
+
+- name: 古いクラスタの削除スクリプトの保存
+  copy:
+    src: /tmp/delete_old_cluster.sh
+    dest: /root/delete_old_cluster.sh
+    remote_src: yes
+    mode: 0700
+  when: ansible_check_mode == false

--- a/ikatodon/infra/database/ansible/roles/postgresql/templates/pg_hba.conf.j2
+++ b/ikatodon/infra/database/ansible/roles/postgresql/templates/pg_hba.conf.j2
@@ -1,0 +1,17 @@
+# PostgreSQL {{ postgresql_version }} クライアント認証設定
+# {{ ansible_managed }}
+
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     peer
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            md5
+# IPv6 local connections:
+host    all             all             ::1/128                 md5
+# Allow from private network
+host    all             all             {{ private_network_cidr }}           md5
+# Allow replication connections
+host    replication     all             127.0.0.1/32            md5
+host    replication     all             ::1/128                 md5
+host    replication     all             {{ private_network_cidr }}           md5

--- a/ikatodon/infra/database/terraform/cloud-init.yml
+++ b/ikatodon/infra/database/terraform/cloud-init.yml
@@ -1,0 +1,23 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - apt-transport-https
+  - ca-certificates
+  - curl
+  - gnupg
+  - lsb-release
+  - python3
+  - python3-pip
+  - python3-setuptools
+
+runcmd:
+  - echo "PostgreSQL 16サーバー初期設定"
+  - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+  - echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+  - apt-get update
+  - apt-get install -y postgresql-16 postgresql-client-16 postgresql-contrib-16
+  - systemctl enable postgresql@16-main
+  - systemctl start postgresql@16-main
+  - echo "初期設定完了"

--- a/ikatodon/infra/database/terraform/environments/production/main.tf
+++ b/ikatodon/infra/database/terraform/environments/production/main.tf
@@ -1,0 +1,41 @@
+terraform {
+  required_providers {
+    conoha = {
+      source = "sacloud/conoha"
+      version = "~> 1.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+  
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+provider "conoha" {
+  user_name     = var.conoha_user_name
+  tenant_name   = var.conoha_tenant_name
+  password      = var.conoha_password
+  auth_url      = var.conoha_auth_url
+  region        = var.conoha_region
+}
+
+module "postgresql_server" {
+  source = "../../modules/postgresql_server"
+  
+  environment         = "production"
+  image_id            = var.image_id
+  flavor_id           = var.flavor_id
+  network_id          = var.network_id
+  private_network_cidr = var.private_network_cidr
+  ssh_key_name        = var.ssh_key_name
+  server_name_prefix  = "pg16-prod"
+}
+
+output "postgresql_new_ip" {
+  value = module.postgresql_server.postgresql_new_ip
+}
+
+output "postgresql_new_private_ip" {
+  value = module.postgresql_server.postgresql_new_private_ip
+}

--- a/ikatodon/infra/database/terraform/environments/production/terraform.tfvars.example
+++ b/ikatodon/infra/database/terraform/environments/production/terraform.tfvars.example
@@ -1,0 +1,11 @@
+# 本番環境設定例（terraform.tfvarsにコピーして使用）
+conoha_user_name = "your-api-username"
+conoha_tenant_name = "your-tenant-name"
+conoha_password = "your-api-password"
+conoha_region = "tyo1"
+
+image_id = "ubuntu-20.04-amd64"
+flavor_id = "g-4gb"
+network_id = "your-network-id"
+private_network_cidr = "192.168.0.0/24"
+ssh_key_name = "your-ssh-key-name"

--- a/ikatodon/infra/database/terraform/environments/production/variables.tf
+++ b/ikatodon/infra/database/terraform/environments/production/variables.tf
@@ -1,0 +1,56 @@
+variable "conoha_user_name" {
+  description = "ConoHa APIユーザー名"
+  type        = string
+}
+
+variable "conoha_tenant_name" {
+  description = "ConoHaテナント名"
+  type        = string
+}
+
+variable "conoha_password" {
+  description = "ConoHa APIパスワード"
+  type        = string
+  sensitive   = true
+}
+
+variable "conoha_auth_url" {
+  description = "ConoHa認証URL"
+  type        = string
+  default     = "https://identity.tyo1.conoha.io/v2.0"
+}
+
+variable "conoha_region" {
+  description = "ConoHaリージョン"
+  type        = string
+  default     = "tyo1"
+}
+
+variable "image_id" {
+  description = "使用するOSイメージID"
+  type        = string
+  default     = "ubuntu-20.04-amd64" # Ubuntu 20.04 LTS
+}
+
+variable "flavor_id" {
+  description = "VPSプラン"
+  type        = string
+  default     = "g-4gb" # 4GB RAM
+}
+
+variable "network_id" {
+  description = "ネットワークID"
+  type        = string
+}
+
+variable "private_network_cidr" {
+  description = "プライベートネットワークCIDR"
+  type        = string
+  default     = "192.168.0.0/24"
+}
+
+variable "ssh_key_name" {
+  description = "SSHキー名"
+  type        = string
+  default     = "default"
+}

--- a/ikatodon/infra/database/terraform/main.tf
+++ b/ikatodon/infra/database/terraform/main.tf
@@ -1,0 +1,68 @@
+terraform {
+  required_providers {
+    conoha = {
+      source = "sacloud/conoha"
+      version = "~> 1.0"
+    }
+  }
+  required_version = ">= 1.0.0"
+}
+
+provider "conoha" {
+  user_name     = var.conoha_user_name
+  tenant_name   = var.conoha_tenant_name
+  password      = var.conoha_password
+  auth_url      = var.conoha_auth_url
+  region        = var.conoha_region
+}
+
+resource "conoha_server" "postgresql_new" {
+  name            = "pg16-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  image_id        = var.image_id
+  flavor_id       = var.flavor_id
+  security_groups = ["default", "postgresql"]
+  user_data       = file("${path.module}/cloud-init.yml")
+  
+  network {
+    uuid = var.network_id
+  }
+  
+  tags = {
+    role = "postgresql"
+    version = "16"
+    environment = var.environment
+  }
+}
+
+resource "conoha_security_group" "postgresql" {
+  name        = "postgresql"
+  description = "Allow PostgreSQL inbound traffic"
+}
+
+resource "conoha_security_group_rule" "postgresql" {
+  security_group_id = conoha_security_group.postgresql.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 5432
+  port_range_max    = 5432
+  remote_ip_prefix  = var.private_network_cidr
+}
+
+resource "conoha_security_group_rule" "ssh" {
+  security_group_id = conoha_security_group.postgresql.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+output "postgresql_new_ip" {
+  value = conoha_server.postgresql_new.access_ipv4
+}
+
+output "postgresql_new_private_ip" {
+  value = conoha_server.postgresql_new.network[0].fixed_ip_v4
+}

--- a/ikatodon/infra/database/terraform/modules/postgresql_server/cloud-init.yml
+++ b/ikatodon/infra/database/terraform/modules/postgresql_server/cloud-init.yml
@@ -1,0 +1,23 @@
+#cloud-config
+package_update: true
+package_upgrade: true
+
+packages:
+  - apt-transport-https
+  - ca-certificates
+  - curl
+  - gnupg
+  - lsb-release
+  - python3
+  - python3-pip
+  - python3-setuptools
+
+runcmd:
+  - echo "PostgreSQL 16サーバー初期設定"
+  - curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql-archive-keyring.gpg
+  - echo "deb [signed-by=/usr/share/keyrings/postgresql-archive-keyring.gpg] http://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list
+  - apt-get update
+  - apt-get install -y postgresql-16 postgresql-client-16 postgresql-contrib-16
+  - systemctl enable postgresql@16-main
+  - systemctl start postgresql@16-main
+  - echo "初期設定完了"

--- a/ikatodon/infra/database/terraform/modules/postgresql_server/main.tf
+++ b/ikatodon/infra/database/terraform/modules/postgresql_server/main.tf
@@ -1,0 +1,61 @@
+resource "conoha_server" "postgresql_new" {
+  name            = "${var.server_name_prefix}-${formatdate("YYYYMMDDhhmmss", timestamp())}"
+  image_id        = var.image_id
+  flavor_id       = var.flavor_id
+  security_groups = ["default", conoha_security_group.postgresql.name]
+  user_data       = file("${path.module}/cloud-init.yml")
+  key_name        = var.ssh_key_name
+  
+  network {
+    uuid = var.network_id
+  }
+  
+  tags = {
+    role = "postgresql"
+    version = "16"
+    environment = var.environment
+  }
+}
+
+resource "conoha_security_group" "postgresql" {
+  name        = "postgresql-${var.environment}"
+  description = "Allow PostgreSQL inbound traffic"
+}
+
+resource "conoha_security_group_rule" "postgresql" {
+  security_group_id = conoha_security_group.postgresql.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 5432
+  port_range_max    = 5432
+  remote_ip_prefix  = var.private_network_cidr
+}
+
+resource "conoha_security_group_rule" "ssh" {
+  security_group_id = conoha_security_group.postgresql.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+}
+
+resource "conoha_security_group_rule" "prometheus" {
+  security_group_id = conoha_security_group.postgresql.id
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 9187
+  port_range_max    = 9187
+  remote_ip_prefix  = var.private_network_cidr
+}
+
+output "postgresql_new_ip" {
+  value = conoha_server.postgresql_new.access_ipv4
+}
+
+output "postgresql_new_private_ip" {
+  value = conoha_server.postgresql_new.network[0].fixed_ip_v4
+}

--- a/ikatodon/infra/database/terraform/modules/postgresql_server/variables.tf
+++ b/ikatodon/infra/database/terraform/modules/postgresql_server/variables.tf
@@ -1,0 +1,36 @@
+variable "environment" {
+  description = "環境名"
+  type        = string
+  default     = "production"
+}
+
+variable "image_id" {
+  description = "使用するOSイメージID"
+  type        = string
+}
+
+variable "flavor_id" {
+  description = "VPSプラン"
+  type        = string
+}
+
+variable "network_id" {
+  description = "ネットワークID"
+  type        = string
+}
+
+variable "private_network_cidr" {
+  description = "プライベートネットワークCIDR"
+  type        = string
+}
+
+variable "ssh_key_name" {
+  description = "SSHキー名"
+  type        = string
+}
+
+variable "server_name_prefix" {
+  description = "サーバー名のプレフィックス"
+  type        = string
+  default     = "pg16"
+}

--- a/ikatodon/infra/database/terraform/variables.tf
+++ b/ikatodon/infra/database/terraform/variables.tf
@@ -1,0 +1,56 @@
+variable "conoha_user_name" {
+  description = "ConoHa APIユーザー名"
+  type        = string
+}
+
+variable "conoha_tenant_name" {
+  description = "ConoHaテナント名"
+  type        = string
+}
+
+variable "conoha_password" {
+  description = "ConoHa APIパスワード"
+  type        = string
+  sensitive   = true
+}
+
+variable "conoha_auth_url" {
+  description = "ConoHa認証URL"
+  type        = string
+  default     = "https://identity.tyo1.conoha.io/v2.0"
+}
+
+variable "conoha_region" {
+  description = "ConoHaリージョン"
+  type        = string
+  default     = "tyo1"
+}
+
+variable "image_id" {
+  description = "使用するOSイメージID"
+  type        = string
+  default     = "ubuntu-20.04-amd64" # Ubuntu 20.04 LTS
+}
+
+variable "flavor_id" {
+  description = "VPSプラン"
+  type        = string
+  default     = "g-2gb" # 2GB RAM
+}
+
+variable "network_id" {
+  description = "ネットワークID"
+  type        = string
+}
+
+variable "private_network_cidr" {
+  description = "プライベートネットワークCIDR"
+  type        = string
+  default     = "192.168.0.0/24"
+}
+
+variable "environment" {
+  description = "環境名"
+  type        = string
+  default     = "production"
+}


### PR DESCRIPTION
イカトドンのPostgreSQLサーバー構築・管理のためのインフラストラクチャコードを追加
Ansible設定ファイル（ロール、プレイブック、テンプレート）
Terraformコード（モジュール、環境設定）
vault.ymlは含まれていない（機密情報を含むため）
PostgreSQLアップグレード手順はGitHub Issue #857で管理

---

This pull request introduces a comprehensive setup for managing and upgrading the PostgreSQL server for the Ikatodon Mastodon instance using Ansible and Terraform. The changes include the creation of infrastructure code, configuration files, and scripts for backup, monitoring, and application integration.

### Infrastructure Setup:

* [`ikatodon/infra/database/README.md`](diffhunk://#diff-28501cd08945f48806c8ad037edf32c42d088876e28fa7c2692fccff0a679b9cR1-R77): Added documentation for setting up the PostgreSQL server using Ansible and Terraform, including prerequisites and usage instructions.

### Configuration Management:

* [`ikatodon/infra/database/ansible/group_vars/all.yml`](diffhunk://#diff-a4eb4bbcb0d15c7525bce006a69bd83bf11ce3899c3029fae91076281e98676aR1-R42): Defined common variables for PostgreSQL configuration, database settings, backup, and monitoring.
* [`ikatodon/infra/database/ansible/host_vars/pg01.yml`](diffhunk://#diff-2dbec131691752f387e7ca8076f2782e3008ed24076ff72620bddd396f9c5fc2R1-R18): Added host-specific variables for the current PostgreSQL server.
* [`ikatodon/infra/database/ansible/host_vars/pg_new.yml`](diffhunk://#diff-334bbe4f1fa1cf03dc0b1cb986a3d13c3f12e96378292e16db2a7f5e32767abcR1-R18): Added host-specific variables for the new PostgreSQL server.
* [`ikatodon/infra/database/ansible/inventory/production`](diffhunk://#diff-7c44e76f963f7895ab7d2b7c57a96bb78a4f640376cc207398202987622c4e9dR1-R27): Created inventory file listing PostgreSQL, web, and Redis servers, along with group definitions.

### Backup and Monitoring:

* [`ikatodon/infra/database/ansible/roles/backup/tasks/main.yml`](diffhunk://#diff-582ce87e5284889ad2c3641e1eff9fb696cb9874978972ea4f3dc145f758e163R1-R43): Added tasks for setting up backup directories, creating backup scripts, and configuring cron jobs for backups and backup rotation.
* [`ikatodon/infra/database/ansible/roles/monitoring/tasks/main.yml`](diffhunk://#diff-250040950d594a9202905aa0162e51145b7833ddec032ea0ab040570fa3caff3R1-R69): Added tasks for installing and configuring Prometheus Node Exporter and PostgreSQL Exporter, and setting up monitoring scripts and cron jobs.

### Application Integration:

* [`ikatodon/infra/database/ansible/roles/mastodon/tasks/main.yml`](diffhunk://#diff-8c826915d9d21906b787d3836df001f487733006e5ad957d6a355c015e11d2a4R1-R46): Added tasks for checking the existence of Mastodon user and directories, updating database connection settings, and restarting Mastodon services.