### PR TITLE
ファイル同期cronを追加

### DIFF
--- a/.github/workflows/ikatodon-storage-rclone-sync.yml
+++ b/.github/workflows/ikatodon-storage-rclone-sync.yml
@@ -18,13 +18,13 @@ jobs:
           docker run --rm \
             -e RCLONE_CONFIG_WASABI_TYPE=s3 \
             -e RCLONE_CONFIG_WASABI_PROVIDER=Wasabi \
-            -e RCLONE_CONFIG_WASABI_ACCESS_KEY_ID=${{ secrets.WASABI_ACCESS_KEY_ID }} \
-            -e RCLONE_CONFIG_WASABI_SECRET_ACCESS_KEY=${{ secrets.WASABI_SECRET_ACCESS_KEY }} \
+            -e RCLONE_CONFIG_WASABI_ACCESS_KEY_ID="${{ secrets.WASABI_ACCESS_KEY_ID }}" \
+            -e RCLONE_CONFIG_WASABI_SECRET_ACCESS_KEY="${{ secrets.WASABI_SECRET_ACCESS_KEY }}" \
             -e RCLONE_CONFIG_WASABI_REGION=us-west-1 \
             -e RCLONE_CONFIG_WASABI_ENDPOINT=s3.us-west-1.wasabisys.com \
             -e RCLONE_CONFIG_B2_TYPE=b2 \
-            -e RCLONE_CONFIG_B2_ACCOUNT=${{ secrets.B2_ACCOUNT }} \
-            -e RCLONE_CONFIG_B2_KEY=${{ secrets.B2_KEY }} \
+            -e RCLONE_CONFIG_B2_ACCOUNT="${{ secrets.B2_ACCOUNT }}" \
+            -e RCLONE_CONFIG_B2_KEY="${{ secrets.B2_KEY }}" \
             rclone/rclone sync wasabi:ikatodon-media b2:ikatodon-media \
             --fast-list \
             --size-only \

--- a/.github/workflows/ikatodon-storage-rclone-sync.yml
+++ b/.github/workflows/ikatodon-storage-rclone-sync.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Rclone Sync
         run: |

--- a/.github/workflows/ikatodon-storage-rclone-sync.yml
+++ b/.github/workflows/ikatodon-storage-rclone-sync.yml
@@ -8,6 +8,8 @@ on:
     - cron: '0 */2 * * *' # 2時間ごと
   workflow_dispatch: # 手動実行も可能に
 
+permissions: {}
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -26,6 +28,7 @@ jobs:
             -e RCLONE_CONFIG_B2_ACCOUNT="${{ secrets.B2_ACCOUNT }}" \
             -e RCLONE_CONFIG_B2_KEY="${{ secrets.B2_KEY }}" \
             rclone/rclone sync wasabi:ikatodon-media b2:ikatodon-media \
+            -v \
             --fast-list \
             --size-only \
             --transfers 32 \

--- a/.github/workflows/ikatodon-storage-rclone-sync.yml
+++ b/.github/workflows/ikatodon-storage-rclone-sync.yml
@@ -1,0 +1,31 @@
+# ストレージ移行完了させるまでのファイル同期を定期的に実行するcron
+# 無料範囲を超えない程度に実行する
+# 1回でだいたい5分前後かかる（ローカルPCだと）
+name: Ikatodon Storage Rclone Sync
+
+on:
+  schedule:
+    - cron: '0 */2 * * *' # 2時間ごと
+  workflow_dispatch: # 手動実行も可能に
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Rclone Sync
+        run: |
+          docker run --rm \
+            -e RCLONE_CONFIG_WASABI_TYPE=s3 \
+            -e RCLONE_CONFIG_WASABI_PROVIDER=Wasabi \
+            -e RCLONE_CONFIG_WASABI_ACCESS_KEY_ID=${{ secrets.WASABI_ACCESS_KEY_ID }} \
+            -e RCLONE_CONFIG_WASABI_SECRET_ACCESS_KEY=${{ secrets.WASABI_SECRET_ACCESS_KEY }} \
+            -e RCLONE_CONFIG_WASABI_REGION=us-west-1 \
+            -e RCLONE_CONFIG_WASABI_ENDPOINT=s3.us-west-1.wasabisys.com \
+            -e RCLONE_CONFIG_B2_TYPE=b2 \
+            -e RCLONE_CONFIG_B2_ACCOUNT=${{ secrets.B2_ACCOUNT }} \
+            -e RCLONE_CONFIG_B2_KEY=${{ secrets.B2_KEY }} \
+            rclone/rclone sync wasabi:ikatodon-media b2:ikatodon-media \
+            --fast-list \
+            --size-only \
+            --transfers 32 \
+            --checkers 64

--- a/.github/workflows/ikatodon-storage-rclone-sync.yml
+++ b/.github/workflows/ikatodon-storage-rclone-sync.yml
@@ -29,6 +29,7 @@ jobs:
             -e RCLONE_CONFIG_B2_KEY="${{ secrets.B2_KEY }}" \
             rclone/rclone sync wasabi:ikatodon-media b2:ikatodon-media \
             -v \
+            --max-delete 1000 \
             --fast-list \
             --size-only \
             --transfers 32 \


### PR DESCRIPTION
wasabi -> b2 の同期を定期的に実行するcronを追加

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automates cross-cloud storage replication and deletion behavior (`rclone sync`), so misconfiguration or credential issues could cause unintended data deletions or increased transfer costs.
> 
> **Overview**
> Adds a new GitHub Actions workflow that **runs every 2 hours (and can be manually triggered)** to sync the `ikatodon-media` bucket from Wasabi (S3) to Backblaze B2 using `rclone` in a Docker container.
> 
> The job uses repository secrets for storage credentials and configures `rclone sync` with verbose logging plus performance/deletion limits (e.g., `--max-delete 1000`, high `--transfers/--checkers`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 904981f41c3523c3f70ebf7c484f2781e4db12e3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->