### PR TITLE
イカトドンリポジトリでissueを作れるようにする

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: GitHub Discussions
-    url: https://github.com/mastodon/mastodon/discussions
+    url: https://github.com/koba-lab/mastodon/discussions
     about: Please ask and answer questions here.


### PR DESCRIPTION
mastodon本家の運用方針が反映されているので、イカトドンは柔軟にissueを溜めれるようにする