### PR TITLE
master → ikatodon の昇格 PR を自動作成する GHA を追加 + CI ゲートの方針を明記

### DIFF
--- a/.github/workflows/ikatodon-promote-pr.yml
+++ b/.github/workflows/ikatodon-promote-pr.yml
@@ -1,0 +1,76 @@
+name: Create ikatodon promotion PR
+
+# master に変更がマージされたら、本番相当の ikatodon へ反映するための PR を自動作成する。
+# 既に同じ PR が開いていれば GitHub が自動で追随するため、何もせず既存 PR を報告する。
+#
+# 注意: 既定の GITHUB_TOKEN で作成した PR では CI がトリガーされない (GitHub の仕様)。
+# ikatodon に必須ステータスチェックを設定している場合は、PAT を
+# secrets.IKATODON_PROMOTE_TOKEN (contents:read / pull-requests:write) に登録すること。
+# 未登録なら GITHUB_TOKEN にフォールバックする。
+
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ikatodon-promote-pr
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or report the master to ikatodon pull request
+        env:
+          GH_TOKEN: ${{ secrets.IKATODON_PROMOTE_TOKEN || secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BASE: ikatodon
+          HEAD: master
+        run: |
+          set -euo pipefail
+
+          owner="${GH_REPO%%/*}"
+
+          # リポジトリを clone せずに差分を取る (mastodon は clone が重いため)
+          compare="$(gh api "repos/${GH_REPO}/compare/${BASE}...${HEAD}")"
+          ahead="$(jq -r '.ahead_by' <<<"$compare")"
+
+          if [ "$ahead" -eq 0 ]; then
+            echo "\`${BASE}\` は \`${HEAD}\` に追いついています。作成する PR はありません。" >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          existing="$(gh api \
+            "repos/${GH_REPO}/pulls?state=open&base=${BASE}&head=${owner}:${HEAD}" \
+            --jq '.[0].html_url // empty')"
+
+          if [ -n "$existing" ]; then
+            echo "既存の PR に ${ahead} コミットが反映されています: ${existing}" >>"$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          body="$(jq -r '
+            "`master` にマージされた変更を本番相当の `ikatodon` へ反映する PR です。\n"
+            + "`.github/workflows/ikatodon-promote-pr.yml` により自動作成されました。\n\n"
+            + "## 反映されるコミット (" + (.ahead_by | tostring) + " 件)\n\n"
+            + ([.commits[] | "- " + .sha[0:7] + " " + (.commit.message | split("\n")[0])]
+               | reverse | join("\n"))
+            + "\n\nマージ前に、デプロイに必要な作業 (イメージのビルド、マイグレーション) が\n"
+            + "済んでいるかを確認してください。手順は `CLAUDE.md` の「デプロイ」節にあります。\n"
+          ' <<<"$compare")"
+
+          url="$(jq -n \
+            --arg title 'master → ikatodon (本番反映)' \
+            --arg body "$body" \
+            --arg head "$HEAD" \
+            --arg base "$BASE" \
+            '{title: $title, head: $head, base: $base, body: $body}' \
+            | gh api "repos/${GH_REPO}/pulls" --input - --jq '.html_url')"
+
+          echo "PR を作成しました (${ahead} コミット): ${url}" >>"$GITHUB_STEP_SUMMARY"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,23 @@ git diff --stat <上流タグ> HEAD -- <ファイル>   # 出力が空なら上�
 
 この昇格 PR は `.github/workflows/ikatodon-promote-pr.yml` が `master` への push を検知して自動作成します。既に開いている昇格 PR があれば GitHub が自動で追随するため、重複して作られることはありません。マージするかどうかは常に人間の判断です。
 
-> 既定の `GITHUB_TOKEN` で作成した PR では CI がトリガーされません（GitHub の仕様）。`ikatodon` に必須ステータスチェックを設定する場合は、PAT を `secrets.IKATODON_PROMOTE_TOKEN` に登録してください（`contents:read` / `pull-requests:write`）。未登録なら `GITHUB_TOKEN` にフォールバックします。
+### CI のゲートは `master` 側に置く
+
+必須ステータスチェック（ruleset の "Require status checks to pass"）は **`master` にだけ設定し、`ikatodon` には設定しません**。コードが入ってくる入口は `master` であり、`ikatodon` へは master で CI を通した内容しか流れてこないためです。
+
+この配置には実利もあります。既定の `GITHUB_TOKEN` で作成した PR では CI がトリガーされない（ワークフローの再帰実行を防ぐ GitHub の仕様）ため、`ikatodon` に必須チェックを設定すると、自動作成された昇格 PR はチェックが永久に報告されずマージ不能になります。ゲートを `master` 側に置けばこの問題が起きず、PAT も不要です。
+
+どうしても `ikatodon` 側にも必須チェックが必要になった場合は、PAT を `secrets.IKATODON_PROMOTE_TOKEN` に登録してください（`contents:read` / `pull-requests:write`）。未登録なら `GITHUB_TOKEN` にフォールバックします。
+
+必須にするチェックを選ぶときの注意:
+
+- **`paths` フィルタ付きのワークフローを必須にしない。** `lint-ruby` / `lint-js` / `lint-css` / `lint-haml` / `test-js` / `test-migrations` などは変更パスによっては丸ごと実行されません。必須にするとドキュメントだけの PR が "Expected — Waiting for status" で永久に止まります
+- **`lint` という名前を指定しない。** `format-check` と `lint-*` の 5 本がどれもジョブ名 `lint` で、名前の文字列照合では区別できません
+- 常に実行されるのは `test-ruby.yml` と `format-check.yml` の 2 本だけです（`check-i18n` と `codeql` は `branches: [main, stable-*]` 指定のため `master` / `ikatodon` では発火しません）。名前が一意でパスフィルタもない **`test (.ruby-version)`** が第一候補です
+
+### `ikatodon` への直接マージについて
+
+`master` 以外から `ikatodon` へマージすることは、規約として避けます。ただし GitHub には base/head の組み合わせを制限する機能がないため、機械的には強制していません（強制するにはガード用ワークフローを `ikatodon` の必須チェックにする必要があり、上記の PAT 問題が再発します）。
 
 ## 上流バージョン追随の手順
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,10 @@ git diff --stat <上流タグ> HEAD -- <ファイル>   # 出力が空なら上�
 
 機能 PR は `master` にマージし、その後 `master` → `ikatodon` の PR で本番へ反映します。
 
+この昇格 PR は `.github/workflows/ikatodon-promote-pr.yml` が `master` への push を検知して自動作成します。既に開いている昇格 PR があれば GitHub が自動で追随するため、重複して作られることはありません。マージするかどうかは常に人間の判断です。
+
+> 既定の `GITHUB_TOKEN` で作成した PR では CI がトリガーされません（GitHub の仕様）。`ikatodon` に必須ステータスチェックを設定する場合は、PAT を `secrets.IKATODON_PROMOTE_TOKEN` に登録してください（`contents:read` / `pull-requests:write`）。未登録なら `GITHUB_TOKEN` にフォールバックします。
+
 ## 上流バージョン追随の手順
 
 1. 上流タグを fetch する


### PR DESCRIPTION
## 概要

`master` に変更がマージされたら、本番相当の `ikatodon` へ反映するための PR を自動作成するワークフローを追加します。これまで #878 / #879 のように手動で作っていた昇格 PR が自動化されます。

あわせて、**CI の必須ステータスチェックを `master` 側に置く**方針を `CLAUDE.md` に明記しました（後述）。

`.github/workflows/` と `CLAUDE.md` はどちらも上流に存在しないファイルなので、この追加が上流マージで衝突することはありません。

## ワークフローの挙動

| 状況 | 動作 |
|---|---|
| `master` が `ikatodon` より進んでいて、昇格 PR が未作成 | PR を作成する |
| 昇格 PR が既に開いている | **何もしない**。GitHub がブランチ PR を自動追随するため、既存 PR の URL を Step Summary に出すだけ |
| `ikatodon` が `master` に追いついている（`ahead_by == 0`） | 何もしない |

トリガーは `master` への push と `workflow_dispatch`（手動実行）です。マージするかどうかは常に人間の判断で、自動マージはしません。

## 実装上の判断

**checkout しない。** mastodon はリポジトリが大きく clone が重いため、`actions/checkout` を使わず GitHub の compare API (`repos/{repo}/compare/ikatodon...master`) だけで差分を取得しています。PR 作成も `gh api ... --input -` で JSON を直接投げているため、git のワークツリーを一切必要としません。

**`concurrency` で直列化。** 短時間に複数のマージが `master` へ landing した場合に、同じ昇格 PR が二重に作られるのを防ぎます（`cancel-in-progress: false` なので後続の実行も落とさず順番に処理します）。

**PR 本文に反映コミット一覧を載せる。** compare API の `commits` は古い順に返るので、`reverse` して新しい順に並べています。あわせて、マージ前にデプロイ作業（イメージのビルド、マイグレーション）の要否を確認するよう促す一文を入れました。

## CI ゲートは `master` 側に置く

レビュー中に「CI が通っていないのにマージできてしまうのを塞ぐべきか」という論点が出たため、方針を決めて `CLAUDE.md` に記録しました。

**必須ステータスチェックは `master` にだけ設定し、`ikatodon` には設定しません。** コードが入ってくる入口は `master` であり、`ikatodon` へは master で CI を通した内容しか流れてこないためです。

この配置には実利もあります。既定の `GITHUB_TOKEN` で作成した PR では CI がトリガーされない（ワークフローの再帰実行を防ぐ GitHub の仕様）ため、`ikatodon` に必須チェックを設定すると、**自動作成された昇格 PR はチェックが永久に報告されずマージ不能**になります。ゲートを `master` 側に置けばこの問題が起きず、PAT も不要です。

将来 `ikatodon` 側にも必須チェックが必要になった場合に備えて、PAT へのフォールバックだけは用意してあります。

```yaml
GH_TOKEN: ${{ secrets.IKATODON_PROMOTE_TOKEN || secrets.GITHUB_TOKEN }}
```

`secrets.IKATODON_PROMOTE_TOKEN` が未登録なら `GITHUB_TOKEN` にフォールバックするので、**現状は何も登録せずそのまま動きます。**

### 必須チェックに何を選ぶか（罠が 2 つある）

ワークフローの実データを調べた結果を `CLAUDE.md` に残しました。

**罠 1: `paths` フィルタ。** このリポジトリでは 9 本のワークフローが `paths` フィルタ付きです（`lint-ruby` / `lint-js` / `lint-css` / `lint-haml` / `test-js` / `test-migrations` など）。実際 #882 は 27 チェック、本 PR は 19 チェックで、変更パスによって走るチェックの集合が変わります。パスフィルタ付きを必須にすると、ドキュメントだけの PR が "Expected — Waiting for status" で永久に止まります。

**罠 2: `lint` という名前の重複。** `format-check` と `lint-ruby` / `lint-js` / `lint-css` / `lint-haml` の 5 本が、どれもジョブ名 `lint` です。必須チェックは名前の文字列で照合するため区別できません。

常に実行されるのは `test-ruby.yml` と `format-check.yml` の 2 本だけです（`check-i18n` と `codeql` は `branches: [main, stable-*]` 指定のため `master` / `ikatodon` では発火しません）。したがって名前が一意でパスフィルタもない **`test (.ruby-version)`** が第一候補になります。

### `ikatodon` への直接マージについて

「`master` 以外から `ikatodon` へマージするのを禁止すべきか」も検討しましたが、**規約として書くに留め、機械的な強制はしません。**

- GitHub には base/head の組み合わせを制限する機能がありません。やるならガード用ワークフローを `ikatodon` の必須チェックにする形になりますが、それは上記の PAT 問題を再発させます
- `master → ikatodon` は #878 / #879（8/3）が最初で、それ以前は #865「To 4.5.5」を含め feature ブランチから直接 `ikatodon` へ入っていました。運用が変わったばかりで、今固めるのは早いと判断しました

## 検証

GitHub Actions 上で実際に動かす前に、ワークフローのシェル部分を抜き出し、`gh` をスタブに差し替えて 3 系統すべてを実行しました。compare API のレスポンスは、ローカルの `git log origin/ikatodon..origin/master` から本物の API と同じ形（`ahead_by` / `commits[].sha` / `commits[].commit.message`）に組み立てた fixture を使っています。

| ケース | 結果 |
|---|---|
| PR 未作成（`ahead_by = 11`） | ✅ PR 作成 API が 1 回呼ばれ、payload は `{title, head: master, base: ikatodon, body}` |
| 昇格 PR が既に開いている | ✅ **PR 作成 API を呼ばない**。既存 URL を報告して終了 |
| `ahead_by = 0` | ✅ **PR 作成 API を呼ばない**。何もせず終了 |

生成された PR 本文（実データでのレンダリング結果）:

```
`master` にマージされた変更を本番相当の `ikatodon` へ反映する PR です。
`.github/workflows/ikatodon-promote-pr.yml` により自動作成されました。

## 反映されるコミット (11 件)

- 091a788 Merge pull request #882 from koba-lab/claude/mastodon-update-pr-afplyy
- 9de490f CLAUDE.md にイカトドンの開発方針と上流追随手順を追加
- cc4b8a4 Merge remote-tracking tag 'v4.6.5' into claude/mastodon-update-pr-afplyy
- 1440d55 Bump version to v4.6.5
  ...
- 2096076 Cancel emoji search requests (#39947)

マージ前に、デプロイに必要な作業 (イメージのビルド、マイグレーション) が
済んでいるかを確認してください。手順は `CLAUDE.md` の「デプロイ」節にあります。
```

その他:

- `shellcheck -s bash`: 指摘なし
- `yarn format:check`: 870 files, all correct
- YAML パース確認済み（トリガー / permissions / steps）

## マージ後の初回動作について

この PR が `master` にマージされた時点でワークフローが動き、**v4.6.5 を含む 12 コミットの昇格 PR が自動作成される想定**です（現在 `ikatodon` は v4.6.5 前の状態）。意図した動作かどうか、最初の 1 回は結果を確認するのが安全です。