### PR TITLE
自動作成する master → ikatodon PR のタイトルを PR 番号ベースにし、本文を削る

### DIFF
--- a/.github/workflows/ikatodon-promote-pr.yml
+++ b/.github/workflows/ikatodon-promote-pr.yml
@@ -47,12 +47,18 @@ jobs:
             exit 0
           fi
 
-          # Mastodon のバージョン (タイトルで各回の昇格 PR を識別できるようにする)
-          version="$(gh api -H 'Accept: application/vnd.github.raw' \
-            "repos/${GH_REPO}/contents/lib/mastodon/version.rb?ref=${HEAD}" \
-            | awk '/def (major|minor|patch)$/ {
-                     getline; gsub(/[^0-9]/, ""); printf "%s%s", sep, $0; sep="."
-                   }')"
+          # Mastodon のバージョン (タイトルで各回の昇格 PR を識別できるようにする)。
+          # version.rb が読めなくても昇格 PR の作成自体は続行したいので、
+          # set -e で止まらないよう if で受けること
+          version=""
+          if version_rb="$(gh api -H 'Accept: application/vnd.github.raw' \
+               "repos/${GH_REPO}/contents/lib/mastodon/version.rb?ref=${HEAD}")"; then
+            version="$(awk '/def (major|minor|patch)$/ {
+                             getline; gsub(/[^0-9]/, ""); printf "%s%s", sep, $0; sep="."
+                           }' <<<"$version_rb")"
+          else
+            echo "::warning::lib/mastodon/version.rb を取得できませんでした。タイトルからバージョンを省きます"
+          fi
 
           title="master → ikatodon"
           [ -n "$version" ] && title="${title} v${version}"
@@ -73,15 +79,33 @@ jobs:
             migration_note="**あり (${migrations} 本)**"
           fi
 
-          # commits も 250 件で打ち切られる
-          commits_md="$(jq -r '
-            [.commits[] | "- " + .sha[0:7] + " " + (.commit.message | split("\n")[0])]
-            | reverse | join("\n")
-          ' <<<"$compare")"
-          shown="$(jq -r '.commits | length' <<<"$compare")"
+          # compare API の commits はページ指定なしだと「古い方から」250 件で打ち切られる。
+          # 打ち切られている場合は最終ページを取り直して新しい方を表示する
+          # (files と ahead_by は最初のレスポンスのものを使い続ける)
+          commits_json="$(jq -c '.commits' <<<"$compare")"
+          shown="$(jq -r 'length' <<<"$commits_json")"
+          commits_note=""
+
           if [ "$shown" -lt "$ahead" ]; then
-            commits_md="${commits_md}"$'\n'"- ... (全 ${ahead} 件のうち新しい ${shown} 件を表示)"
+            per_page=100
+            last_page=$(( (ahead + per_page - 1) / per_page ))
+            if paged="$(gh api \
+                 "repos/${GH_REPO}/compare/${BASE}...${HEAD}?per_page=${per_page}&page=${last_page}" \
+                 --jq '.commits')" && [ "$(jq -r 'length' <<<"$paged")" -gt 0 ]; then
+              commits_json="$paged"
+              shown="$(jq -r 'length' <<<"$commits_json")"
+              commits_note="- ... (全 ${ahead} 件のうち新しい ${shown} 件を表示)"
+            else
+              # 取り直せなかった場合、手元にあるのは「古い方」なのでそう明記する
+              commits_note="- ... (全 ${ahead} 件のうち古い ${shown} 件を表示)"
+            fi
           fi
+
+          commits_md="$(jq -r '
+            [.[] | "- " + .sha[0:7] + " " + (.commit.message | split("\n")[0])]
+            | reverse | join("\n")
+          ' <<<"$commits_json")"
+          [ -n "$commits_note" ] && commits_md="${commits_md}"$'\n'"${commits_note}"
 
           # ヒアドキュメントの中身はそのまま PR 本文になる
           # (run: | ブロックのインデントは YAML 側で剥がされるため、ここでの整形は不要)

--- a/.github/workflows/ikatodon-promote-pr.yml
+++ b/.github/workflows/ikatodon-promote-pr.yml
@@ -97,20 +97,6 @@ jobs:
           ## 含まれる変更
 
           ${changes}
-
-          ## デプロイ手順
-
-          デプロイ作業は**この PR をマージしたあと**に行います。マージ前に必要な準備はありません。
-
-          1. \`${BASE}\` にタグを打つ → \`ikatodon-build.yml\` が ghcr へイメージをビルドする
-          2. \`docker compose pull\`
-          3. マイグレーションがある場合は先に流す
-             \`docker compose run --rm web env SKIP_POST_DEPLOYMENT_MIGRATIONS=true bundle exec rails db:migrate\`
-          4. \`docker compose up -d\` で web を入れ替える
-          5. マイグレーションがある場合は post-deployment 分を流す
-             \`docker compose run --rm web bundle exec rails db:migrate\`
-
-          詳細は \`CLAUDE.md\` の「デプロイ」節を参照してください。
           EOF
           )"
 

--- a/.github/workflows/ikatodon-promote-pr.yml
+++ b/.github/workflows/ikatodon-promote-pr.yml
@@ -1,12 +1,13 @@
 name: Create ikatodon promotion PR
 
 # master に変更がマージされたら、本番相当の ikatodon へ反映するための PR を自動作成する。
-# 既に同じ PR が開いていれば GitHub が自動で追随するため、何もせず既存 PR を報告する。
+# 既に昇格 PR が開いていればタイトルと本文を最新の内容に更新する
+# (開いている間に master が進んでバージョンやコミット一覧が変わるため)。
 #
 # 注意: 既定の GITHUB_TOKEN で作成した PR では CI がトリガーされない (GitHub の仕様)。
-# ikatodon に必須ステータスチェックを設定している場合は、PAT を
-# secrets.IKATODON_PROMOTE_TOKEN (contents:read / pull-requests:write) に登録すること。
-# 未登録なら GITHUB_TOKEN にフォールバックする。
+# CI のゲートは master 側に置く方針なので通常は問題ないが、ikatodon にも必須ステータス
+# チェックを設定する場合は PAT を secrets.IKATODON_PROMOTE_TOKEN に登録すること
+# (contents:read / pull-requests:write)。未登録なら GITHUB_TOKEN にフォールバックする。
 
 on:
   push:
@@ -26,7 +27,7 @@ jobs:
   promote:
     runs-on: ubuntu-latest
     steps:
-      - name: Create or report the master to ikatodon pull request
+      - name: Create or update the master to ikatodon pull request
         env:
           GH_TOKEN: ${{ secrets.IKATODON_PROMOTE_TOKEN || secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -46,31 +47,87 @@ jobs:
             exit 0
           fi
 
-          existing="$(gh api \
-            "repos/${GH_REPO}/pulls?state=open&base=${BASE}&head=${owner}:${HEAD}" \
-            --jq '.[0].html_url // empty')"
+          # Mastodon のバージョン (タイトルで各回の昇格 PR を識別できるようにする)
+          version="$(gh api -H 'Accept: application/vnd.github.raw' \
+            "repos/${GH_REPO}/contents/lib/mastodon/version.rb?ref=${HEAD}" \
+            | awk '/def (major|minor|patch)$/ {
+                     getline; gsub(/[^0-9]/, ""); printf "%s%s", sep, $0; sep="."
+                   }')"
 
-          if [ -n "$existing" ]; then
-            echo "既存の PR に ${ahead} コミットが反映されています: ${existing}" >>"$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
+          title="master → ikatodon"
+          [ -n "$version" ] && title="${title} v${version}"
+          title="${title} ($(TZ=Asia/Tokyo date +%Y-%m-%d))"
 
-          body="$(jq -r '
-            "`master` にマージされた変更を本番相当の `ikatodon` へ反映する PR です。\n"
-            + "`.github/workflows/ikatodon-promote-pr.yml` により自動作成されました。\n\n"
-            + "## 反映されるコミット (" + (.ahead_by | tostring) + " 件)\n\n"
-            + ([.commits[] | "- " + .sha[0:7] + " " + (.commit.message | split("\n")[0])]
-               | reverse | join("\n"))
-            + "\n\nマージ前に、デプロイに必要な作業 (イメージのビルド、マイグレーション) が\n"
-            + "済んでいるかを確認してください。手順は `CLAUDE.md` の「デプロイ」節にあります。\n"
+          # 新規マイグレーションの有無。compare API の files は 300 件で打ち切られるため、
+          # 打ち切りが疑われる場合は「なし」と誤って言い切らずに手元での確認を促す
+          files_len="$(jq -r '.files | length' <<<"$compare")"
+          migrations="$(jq -r '
+            [.files[]? | select(.filename | test("^db/(migrate|post_migrate)/"))] | length
           ' <<<"$compare")"
 
-          url="$(jq -n \
-            --arg title 'master → ikatodon (本番反映)' \
-            --arg body "$body" \
-            --arg head "$HEAD" \
-            --arg base "$BASE" \
-            '{title: $title, head: $head, base: $base, body: $body}' \
-            | gh api "repos/${GH_REPO}/pulls" --input - --jq '.html_url')"
+          if [ "$files_len" -ge 300 ]; then
+            migration_note="変更ファイルが多く自動判定できません。\`git diff --stat ${BASE} ${HEAD} -- db/\` で確認してください"
+          elif [ "$migrations" -eq 0 ]; then
+            migration_note="なし (マイグレーション手順は不要)"
+          else
+            migration_note="**あり (${migrations} 本)**"
+          fi
 
-          echo "PR を作成しました (${ahead} コミット): ${url}" >>"$GITHUB_STEP_SUMMARY"
+          # commits も 250 件で打ち切られる
+          commits_md="$(jq -r '
+            [.commits[] | "- " + .sha[0:7] + " " + (.commit.message | split("\n")[0])]
+            | reverse | join("\n")
+          ' <<<"$compare")"
+          shown="$(jq -r '.commits | length' <<<"$compare")"
+          if [ "$shown" -lt "$ahead" ]; then
+            commits_md="${commits_md}"$'\n'"- ... (全 ${ahead} 件のうち新しい ${shown} 件を表示)"
+          fi
+
+          # ヒアドキュメントの中身はそのまま PR 本文になる
+          # (run: | ブロックのインデントは YAML 側で剥がされるため、ここでの整形は不要)
+          body="$(cat <<EOF
+          \`master\` にマージされた変更を本番相当の \`ikatodon\` へ反映する PR です。
+          \`.github/workflows/ikatodon-promote-pr.yml\` が自動作成し、\`master\` に push があるたびに更新します。
+
+          | | |
+          |---|---|
+          | Mastodon バージョン | v${version:-?} |
+          | 反映コミット数 | ${ahead} |
+          | 新規マイグレーション | ${migration_note} |
+
+          ## 反映されるコミット
+
+          ${commits_md}
+
+          ## デプロイ手順
+
+          デプロイ作業は**この PR をマージしたあと**に行います。マージ前に必要な準備はありません。
+
+          1. \`${BASE}\` にタグを打つ → \`ikatodon-build.yml\` が ghcr へイメージをビルドする
+          2. \`docker compose pull\`
+          3. マイグレーションがある場合は先に流す
+             \`docker compose run --rm web env SKIP_POST_DEPLOYMENT_MIGRATIONS=true bundle exec rails db:migrate\`
+          4. \`docker compose up -d\` で web を入れ替える
+          5. マイグレーションがある場合は post-deployment 分を流す
+             \`docker compose run --rm web bundle exec rails db:migrate\`
+
+          詳細は \`CLAUDE.md\` の「デプロイ」節を参照してください。
+          EOF
+          )"
+
+          number="$(gh api \
+            "repos/${GH_REPO}/pulls?state=open&base=${BASE}&head=${owner}:${HEAD}" \
+            --jq '.[0].number // empty')"
+
+          payload="$(jq -n --arg title "$title" --arg body "$body" \
+            --arg head "$HEAD" --arg base "$BASE" \
+            '{title: $title, head: $head, base: $base, body: $body}')"
+
+          if [ -n "$number" ]; then
+            url="$(jq 'del(.head, .base)' <<<"$payload" \
+              | gh api --method PATCH "repos/${GH_REPO}/pulls/${number}" --input - --jq '.html_url')"
+            echo "既存の昇格 PR を更新しました (${ahead} コミット): ${url}" >>"$GITHUB_STEP_SUMMARY"
+          else
+            url="$(gh api "repos/${GH_REPO}/pulls" --input - --jq '.html_url' <<<"$payload")"
+            echo "昇格 PR を作成しました (${ahead} コミット): ${url}" >>"$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/ikatodon-promote-pr.yml
+++ b/.github/workflows/ikatodon-promote-pr.yml
@@ -1,8 +1,8 @@
-name: Create ikatodon promotion PR
+name: Create ikatodon PR
 
-# master に変更がマージされたら、本番相当の ikatodon へ反映するための PR を自動作成する。
-# 既に昇格 PR が開いていればタイトルと本文を最新の内容に更新する
-# (開いている間に master が進んでバージョンやコミット一覧が変わるため)。
+# master に PR がマージされたら、それを本番相当の ikatodon へ入れるための PR を
+# 自動で作る。これまで手で作っていたものを自動化しただけで、マージするかどうかは
+# 常に人間の判断。既に PR が開いていればタイトルと本文を最新の内容に更新する。
 #
 # 注意: 既定の GITHUB_TOKEN で作成した PR では CI がトリガーされない (GitHub の仕様)。
 # CI のゲートは master 側に置く方針なので通常は問題ないが、ikatodon にも必須ステータス
@@ -47,81 +47,56 @@ jobs:
             exit 0
           fi
 
-          # Mastodon のバージョン (タイトルで各回の昇格 PR を識別できるようにする)。
-          # version.rb が読めなくても昇格 PR の作成自体は続行したいので、
-          # set -e で止まらないよう if で受けること
-          version=""
-          if version_rb="$(gh api -H 'Accept: application/vnd.github.raw' \
-               "repos/${GH_REPO}/contents/lib/mastodon/version.rb?ref=${HEAD}")"; then
-            version="$(awk '/def (major|minor|patch)$/ {
-                             getline; gsub(/[^0-9]/, ""); printf "%s%s", sep, $0; sep="."
-                           }' <<<"$version_rb")"
-          else
-            echo "::warning::lib/mastodon/version.rb を取得できませんでした。タイトルからバージョンを省きます"
-          fi
-
-          title="master → ikatodon"
-          [ -n "$version" ] && title="${title} v${version}"
-          title="${title} ($(TZ=Asia/Tokyo date +%Y-%m-%d))"
-
-          # 新規マイグレーションの有無。compare API の files は 300 件で打ち切られるため、
-          # 打ち切りが疑われる場合は「なし」と誤って言い切らずに手元での確認を促す
-          files_len="$(jq -r '.files | length' <<<"$compare")"
-          migrations="$(jq -r '
-            [.files[]? | select(.filename | test("^db/(migrate|post_migrate)/"))] | length
-          ' <<<"$compare")"
-
-          if [ "$files_len" -ge 300 ]; then
-            migration_note="変更ファイルが多く自動判定できません。\`git diff --stat ${BASE} ${HEAD} -- db/\` で確認してください"
-          elif [ "$migrations" -eq 0 ]; then
-            migration_note="なし (マイグレーション手順は不要)"
-          else
-            migration_note="**あり (${migrations} 本)**"
-          fi
-
-          # compare API の commits はページ指定なしだと「古い方から」250 件で打ち切られる。
-          # 打ち切られている場合は最終ページを取り直して新しい方を表示する
-          # (files と ahead_by は最初のレスポンスのものを使い続ける)
-          commits_json="$(jq -c '.commits' <<<"$compare")"
-          shown="$(jq -r 'length' <<<"$commits_json")"
-          commits_note=""
-
-          if [ "$shown" -lt "$ahead" ]; then
+          # compare の commits はページ指定なしだと「古い方から」250 件で打ち切られる。
+          # master への PR マージコミットは範囲の最も新しい側に集まるため、打ち切られた
+          # ままだと PR 番号を 1 つも拾えない (上流の大規模追随でこれが起きる)。
+          # その場合は最終ページを取り直す。
+          commits="$(jq -c '.commits' <<<"$compare")"
+          if [ "$(jq -r 'length' <<<"$commits")" -lt "$ahead" ]; then
             per_page=100
             last_page=$(( (ahead + per_page - 1) / per_page ))
             if paged="$(gh api \
                  "repos/${GH_REPO}/compare/${BASE}...${HEAD}?per_page=${per_page}&page=${last_page}" \
                  --jq '.commits')" && [ "$(jq -r 'length' <<<"$paged")" -gt 0 ]; then
-              commits_json="$paged"
-              shown="$(jq -r 'length' <<<"$commits_json")"
-              commits_note="- ... (全 ${ahead} 件のうち新しい ${shown} 件を表示)"
+              commits="$paged"
             else
-              # 取り直せなかった場合、手元にあるのは「古い方」なのでそう明記する
-              commits_note="- ... (全 ${ahead} 件のうち古い ${shown} 件を表示)"
+              echo "::warning::コミットが 250 件で打ち切られており、最終ページも取得できませんでした。PR 番号を拾えない可能性があります"
             fi
           fi
 
-          commits_md="$(jq -r '
-            [.[] | "- " + .sha[0:7] + " " + (.commit.message | split("\n")[0])]
-            | reverse | join("\n")
-          ' <<<"$commits_json")"
-          [ -n "$commits_note" ] && commits_md="${commits_md}"$'\n'"${commits_note}"
+          # 「Merge pull request #N from ...」形式のマージコミットから、
+          # 番号とタイトル (メッセージ 3 行目) を取り出す。マージされた順に並ぶ。
+          pr_list="$(jq -r '
+            [ .[]
+              | select(.commit.message | test("^Merge pull request #[0-9]+"))
+              | {
+                  number: (.commit.message | capture("^Merge pull request #(?<n>[0-9]+)").n),
+                  title:  (.commit.message | split("\n") | if length > 2 then .[2] else "" end)
+                }
+            ]
+          ' <<<"$commits")"
+
+          numbers="$(jq -r '[.[].number | "#" + .] | join(", ")' <<<"$pr_list")"
+
+          if [ -n "$numbers" ]; then
+            title="master → ikatodon (PR ${numbers})"
+            changes="$(jq -r '[.[] | "- #" + .number + " " + .title] | join("\n")' <<<"$pr_list")"
+          else
+            # master へ直接 push された場合や、上のページング取得に失敗したとき
+            head_sha="$(jq -r '.commits[-1].sha[0:7] // "unknown"' <<<"$compare")"
+            title="master → ikatodon (${head_sha})"
+            changes="- (PR 番号を特定できませんでした。${ahead} コミット)"
+          fi
 
           # ヒアドキュメントの中身はそのまま PR 本文になる
           # (run: | ブロックのインデントは YAML 側で剥がされるため、ここでの整形は不要)
           body="$(cat <<EOF
-          \`master\` にマージされた変更を本番相当の \`ikatodon\` へ反映する PR です。
+          \`master\` の変更を本番相当の \`${BASE}\` へ入れる PR です。
           \`.github/workflows/ikatodon-promote-pr.yml\` が自動作成し、\`master\` に push があるたびに更新します。
 
-          | | |
-          |---|---|
-          | Mastodon バージョン | v${version:-?} |
-          | 反映コミット数 | ${ahead} |
-          | 新規マイグレーション | ${migration_note} |
+          ## 含まれる変更
 
-          ## 反映されるコミット
-
-          ${commits_md}
+          ${changes}
 
           ## デプロイ手順
 
@@ -150,8 +125,8 @@ jobs:
           if [ -n "$number" ]; then
             url="$(jq 'del(.head, .base)' <<<"$payload" \
               | gh api --method PATCH "repos/${GH_REPO}/pulls/${number}" --input - --jq '.html_url')"
-            echo "既存の昇格 PR を更新しました (${ahead} コミット): ${url}" >>"$GITHUB_STEP_SUMMARY"
+            echo "既存の PR を更新しました: ${url}" >>"$GITHUB_STEP_SUMMARY"
           else
             url="$(gh api "repos/${GH_REPO}/pulls" --input - --jq '.html_url' <<<"$payload")"
-            echo "昇格 PR を作成しました (${ahead} コミット): ${url}" >>"$GITHUB_STEP_SUMMARY"
+            echo "PR を作成しました: ${url}" >>"$GITHUB_STEP_SUMMARY"
           fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,13 +27,15 @@ git diff --stat <上流タグ> HEAD -- <ファイル>   # 出力が空なら上�
 
 機能 PR は `master` にマージし、その後 `master` → `ikatodon` の PR で本番へ反映します。
 
-この昇格 PR は `.github/workflows/ikatodon-promote-pr.yml` が `master` への push を検知して自動作成します。既に開いている昇格 PR があれば GitHub が自動で追随するため、重複して作られることはありません。マージするかどうかは常に人間の判断です。
+この `master` → `ikatodon` の PR は、`.github/workflows/ikatodon-promote-pr.yml` が `master` への push を検知して自動作成します。これまで手で作っていたものを自動化しただけで、マージするかどうかは常に人間の判断です。既に開いている PR があればタイトルと本文が更新されるだけで、重複して作られることはありません。
+
+タイトルは `master → ikatodon (PR #883)` の形になります。番号は運ぶ変更の PR で、辿れば中身が分かります。
 
 ### CI のゲートは `master` 側に置く
 
 必須ステータスチェック（ruleset の "Require status checks to pass"）は **`master` にだけ設定し、`ikatodon` には設定しません**。コードが入ってくる入口は `master` であり、`ikatodon` へは master で CI を通した内容しか流れてこないためです。
 
-この配置には実利もあります。既定の `GITHUB_TOKEN` で作成した PR では CI がトリガーされない（ワークフローの再帰実行を防ぐ GitHub の仕様）ため、`ikatodon` に必須チェックを設定すると、自動作成された昇格 PR はチェックが永久に報告されずマージ不能になります。ゲートを `master` 側に置けばこの問題が起きず、PAT も不要です。
+この配置には実利もあります。既定の `GITHUB_TOKEN` で作成した PR では CI がトリガーされない（ワークフローの再帰実行を防ぐ GitHub の仕様）ため、`ikatodon` に必須チェックを設定すると、自動作成された PR はチェックが永久に報告されずマージ不能になります。ゲートを `master` 側に置けばこの問題が起きず、PAT も不要です。
 
 どうしても `ikatodon` 側にも必須チェックが必要になった場合は、PAT を `secrets.IKATODON_PROMOTE_TOKEN` に登録してください（`contents:read` / `pull-requests:write`）。未登録なら `GITHUB_TOKEN` にフォールバックします。
 


### PR DESCRIPTION
## 概要

`master` → `ikatodon` の PR を自動作成するワークフロー（#883）の、タイトルと本文を変更します。

タイトルは `master → ikatodon (本番反映)` 固定だったため、マージ済みの PR が並んだときにどれが何なのか判別できませんでした。**PR 番号を入れて識別できるようにします。**

## タイトル

| 状況 | タイトル |
|---|---|
| 1 件 | `master → ikatodon (PR #883)` |
| 複数 | `master → ikatodon (PR #882, #883)` |
| 番号を拾えない（`master` への直接 push など） | `master → ikatodon (ec237da)` |

番号は compare 範囲のマージコミット `Merge pull request #N from ...` から取ります。番号を辿れば元の PR に中身が全部書いてあるので、タイトル側で内容を説明する必要がありません。

このリポジトリの `ikatodon` 向け PR は元々「何をしたか」で命名されていました（#879「hcaptcha設定を追加」、#878「to 4.6.4」、#870「ストレージ同期Actionが必要なくなったので削除」）。内容は上流追随のこともあれば独自の変更のこともあり、一律の軸では表せません。PR 番号ならどちらの場合も一意に識別できます。

## 本文

生成される全文です。

```
`master` の変更を本番相当の `ikatodon` へ入れる PR です。
`.github/workflows/ikatodon-promote-pr.yml` が自動作成し、`master` に push があるたびに更新します。

## 含まれる変更

- #882 Mastodon v4.6.4 → v4.6.5 追随 + マイグレーション検証 + CLAUDE.md 追加
- #883 master → ikatodon の昇格 PR を自動作成する GHA を追加 + CI ゲートの方針を明記
```

PR 番号とタイトルはマージコミットから取ります（メッセージ 3 行目が PR タイトル）。

## 実装上の注意点

**compare の 250 件打ち切り。** compare API はページ指定なしだと古い方から 250 件で commits を打ち切ります。`master` への PR マージコミットは範囲の最も新しい側に集まるため、打ち切られたままだと**上流の大規模追随で PR 番号を 1 つも拾えません**（数千コミットが 1 つの PR に入るケース）。打ち切りを検知したら `per_page=100&page=ceil(ahead/100)` で最終ページを取り直します。

**API 取得失敗の扱い。** `set -euo pipefail` のもとではコマンド置換の失敗で step ごと落ちるため、ページ取得は `if` で受けて非致命にしています。失敗時は警告を出し、PR 番号なしのタイトルで続行します。

**clone しない。** mastodon はリポジトリが大きいため `actions/checkout` を使わず、compare API と `gh api --input -` だけで完結させています。

## `CLAUDE.md`

「ブランチ構成」節から「昇格 PR」という語を除き、タイトルの形式を追記しました。`config/locales/ja.yml` の `promote: 昇格` は上流由来のため触っていません。

## 差分

`master` に対して **2 ファイル / +78 -34** です。

## 検証

YAML パーサでワークフローから `run` スクリプトを取り出し、`gh` をスタブに差し替えて実行しました。compare のレスポンスは `git log origin/ikatodon..origin/master` から本物の API と同じ形（マージコミットのメッセージ全文を含む）に組み立てた fixture です。

| ケース | 結果 |
|---|---|
| PR 1 件 | ✅ title `master → ikatodon (PR #883)`、本文に該当 1 行 |
| PR 2 件（実データ） | ✅ title `master → ikatodon (PR #882, #883)`、本文に 2 行 |
| 既存 PR あり | ✅ PATCH のみ。キーは `["body","title"]`。作成 API は呼ばない |
| `ahead_by = 0` | ✅ 作成も更新もしない |
| 250 件打ち切り + PR マージコミットが最終ページ | ✅ `per_page=100&page=6` を要求し `(PR #900)` を拾う |
| 最終ページも取得失敗 | ✅ 警告を出し、`(fffffff)` と「PR 番号を特定できませんでした」で続行 |

その他:

- `shellcheck -s bash`: 指摘なし
- `yarn format:check`: 870 files, all correct
- YAML パース確認済み

## 補足

このブランチは #883 がマージ済みのため `origin/master` から切り直しています。マージ後は #884 のタイトルと本文が上記の形に更新される想定です。