### PR TITLE
ikatodon: デプロイワークフローの Phase 1 (存在確認・ssh 到達性確認) を追加

### DIFF
--- a/.github/workflows/ikatodon-deploy.yml
+++ b/.github/workflows/ikatodon-deploy.yml
@@ -1,0 +1,87 @@
+name: Deploy ikatodon
+
+# 本番 Web サーバーへのデプロイ (issue #876)。
+#
+# 現状は Phase 1 (デプロイ対象の存在確認 + ssh 到達性確認) のみを実装している。
+# 実際の checkout・compose 起動・nginx 切替は後続の PR (Ansible mastodon / nginx role) で追加する。
+#
+# セルフホストランナーは使わない (このフォークはパブリックリポジトリで、フォークからの PR で
+# 任意コードがサーバー上で実行され得るため)。
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'デプロイ対象のタグ名 (例: v4.6.5, v4.6.5.1)'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+concurrency:
+  group: ikatodon-deploy
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ inputs.version }}
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Check that required secrets are set
+        env:
+          ENV_PRODUCTION_SET: ${{ secrets.IKATODON_ENV_PRODUCTION != '' }}
+          SSH_KEY_SET: ${{ secrets.IKATODON_DEPLOY_SSH_KEY != '' }}
+          KNOWN_HOSTS_SET: ${{ secrets.IKATODON_DEPLOY_KNOWN_HOSTS != '' }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ "${ENV_PRODUCTION_SET}" = "true" ] || missing+=(IKATODON_ENV_PRODUCTION)
+          [ "${SSH_KEY_SET}" = "true" ] || missing+=(IKATODON_DEPLOY_SSH_KEY)
+          [ "${KNOWN_HOSTS_SET}" = "true" ] || missing+=(IKATODON_DEPLOY_KNOWN_HOSTS)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::未設定の secrets があります: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Check that the tag exists
+        run: |
+          set -euo pipefail
+          if ! gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
+            echo "::error::タグ ${VERSION} がリポジトリに存在しません"
+            exit 1
+          fi
+
+      - name: Check that the images exist
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          echo "${GH_TOKEN}" | docker login ghcr.io -u "${ACTOR}" --password-stdin
+          docker manifest inspect "ghcr.io/koba-lab/ikatodon:${VERSION}" >/dev/null
+          docker manifest inspect "ghcr.io/koba-lab/ikatodon-streaming:${VERSION}" >/dev/null
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Ansible ssh access
+        env:
+          SSH_KEY: ${{ secrets.IKATODON_DEPLOY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.IKATODON_DEPLOY_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          umask 077
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/ikatodon_deploy
+          printf '%s\n' "${KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/ikatodon_deploy ~/.ssh/known_hosts
+
+      - name: Check ssh reachability of both hosts
+        working-directory: ikatodon/ansible
+        run: |
+          set -euo pipefail
+          ansible all -m ping --private-key ~/.ssh/ikatodon_deploy

--- a/.github/workflows/ikatodon-deploy.yml
+++ b/.github/workflows/ikatodon-deploy.yml
@@ -29,26 +29,39 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ inputs.version }}
-      GH_TOKEN: ${{ github.token }}
-      GH_REPO: ${{ github.repository }}
     steps:
+      - name: Check that this is run by the repository owner
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          if [ "${ACTOR}" != "koba-lab" ]; then
+            echo "::error::このワークフローはリポジトリオーナーのみ実行できます (actor: ${ACTOR})"
+            exit 1
+          fi
+
       - name: Check that required secrets are set
         env:
           ENV_PRODUCTION_SET: ${{ secrets.IKATODON_ENV_PRODUCTION != '' }}
           SSH_KEY_SET: ${{ secrets.IKATODON_DEPLOY_SSH_KEY != '' }}
           KNOWN_HOSTS_SET: ${{ secrets.IKATODON_DEPLOY_KNOWN_HOSTS != '' }}
+          VAULT_PASSWORD_SET: ${{ secrets.IKATODON_ANSIBLE_VAULT_PASSWORD != '' }}
         run: |
           set -euo pipefail
           missing=()
           [ "${ENV_PRODUCTION_SET}" = "true" ] || missing+=(IKATODON_ENV_PRODUCTION)
           [ "${SSH_KEY_SET}" = "true" ] || missing+=(IKATODON_DEPLOY_SSH_KEY)
           [ "${KNOWN_HOSTS_SET}" = "true" ] || missing+=(IKATODON_DEPLOY_KNOWN_HOSTS)
+          [ "${VAULT_PASSWORD_SET}" = "true" ] || missing+=(IKATODON_ANSIBLE_VAULT_PASSWORD)
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "::error::未設定の secrets があります: ${missing[*]}"
             exit 1
           fi
 
       - name: Check that the tag exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           if ! gh api "repos/${GH_REPO}/git/ref/tags/${VERSION}" >/dev/null 2>&1; then
@@ -58,6 +71,7 @@ jobs:
 
       - name: Check that the images exist
         env:
+          GH_TOKEN: ${{ github.token }}
           ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
@@ -67,11 +81,14 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Ansible ssh access
         env:
           SSH_KEY: ${{ secrets.IKATODON_DEPLOY_SSH_KEY }}
           KNOWN_HOSTS: ${{ secrets.IKATODON_DEPLOY_KNOWN_HOSTS }}
+          VAULT_PASSWORD: ${{ secrets.IKATODON_ANSIBLE_VAULT_PASSWORD }}
         run: |
           set -euo pipefail
           umask 077
@@ -79,9 +96,11 @@ jobs:
           printf '%s\n' "${SSH_KEY}" > ~/.ssh/ikatodon_deploy
           printf '%s\n' "${KNOWN_HOSTS}" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/ikatodon_deploy ~/.ssh/known_hosts
+          printf '%s\n' "${VAULT_PASSWORD}" > ~/.ansible_vault_pass
+          chmod 600 ~/.ansible_vault_pass
 
       - name: Check ssh reachability of both hosts
         working-directory: ikatodon/ansible
         run: |
           set -euo pipefail
-          ansible all -m ping --private-key ~/.ssh/ikatodon_deploy
+          ansible all -m ping --private-key ~/.ssh/ikatodon_deploy --vault-password-file ~/.ansible_vault_pass

--- a/ikatodon/ansible/ansible.cfg
+++ b/ikatodon/ansible/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+inventory = inventory/hosts.yml
+host_key_checking = True
+retry_files_enabled = False

--- a/ikatodon/ansible/inventory/hosts.yml
+++ b/ikatodon/ansible/inventory/hosts.yml
@@ -1,0 +1,13 @@
+# 2台の Web サーバー。グローバル IP は ika.queloud.net の A レコードで引けるため記載する
+# （CLAUDE.md 方針）。プライベート IP はここには書かず、Ansible Vault で値単位に暗号化した
+# 変数として別途追加する（infrastructure.md 参照）。
+#
+# ssh のポート番号は既定の 22 と仮定している。実機で異なることが判明したら訂正すること。
+all:
+  hosts:
+    web1:
+      ansible_host: 150.95.184.57
+      ansible_user: mastodon
+    web2:
+      ansible_host: 163.44.167.100
+      ansible_user: mastodon


### PR DESCRIPTION
issue #876 のデプロイ自動化 (2/5)。#893 の上に積む。

workflow_dispatch で対象タグを受け取り、secrets の設定・タグの存在・ghcr.io イメージの存在を確認したうえで、Ansible の ping module で本番 Web 2台への ssh 到達性を確認する。checkout・compose 起動・nginx 切替は後続の PR で追加する。

Ansible inventory の Web 2台のグローバル IP は `ika.queloud.net` の A レコードで引けるため記載した（プライベート IP は含まない）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manually triggered deployment verification process for tagged releases.
  * Added checks for required credentials, release tags, container images, and server connectivity before deployment.
  * Added infrastructure configuration for managing two web servers with consistent connection settings.
  * Improved deployment safety with restricted permissions and protected concurrent execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->