### PR TITLE
ikatodon: Ansible mastodon role を追加し、デプロイワークフローを Phase 2 へ拡張

### DIFF
--- a/.github/workflows/ikatodon-deploy.yml
+++ b/.github/workflows/ikatodon-deploy.yml
@@ -2,8 +2,8 @@ name: Deploy ikatodon
 
 # 本番 Web サーバーへのデプロイ (issue #876)。
 #
-# 現状は Phase 1 (デプロイ対象の存在確認 + ssh 到達性確認) のみを実装している。
-# 実際の checkout・compose 起動・nginx 切替は後続の PR (Ansible mastodon / nginx role) で追加する。
+# 現状は Phase 2 (存在確認・ssh 到達性確認・checkout・.env.production 配布・pull) まで
+# 実装している。up -d・ヘルスチェック・nginx との切替は後続の PR (nginx role) で追加する。
 #
 # セルフホストランナーは使わない (このフォークはパブリックリポジトリで、フォークからの PR で
 # 任意コードがサーバー上で実行され得るため)。
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  verify:
+  deploy:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ inputs.version }}
@@ -104,3 +104,14 @@ jobs:
         run: |
           set -euo pipefail
           ansible all -m ping --private-key ~/.ssh/ikatodon_deploy --vault-password-file ~/.ansible_vault_pass
+
+      - name: Run the mastodon role (checkout, override, .env.production, pull)
+        working-directory: ikatodon/ansible
+        env:
+          IKATODON_ENV_PRODUCTION: ${{ secrets.IKATODON_ENV_PRODUCTION }}
+        run: |
+          set -euo pipefail
+          ansible-playbook playbooks/deploy.yml \
+            --private-key ~/.ssh/ikatodon_deploy \
+            --vault-password-file ~/.ansible_vault_pass \
+            -e "ikatodon_version=${VERSION}"

--- a/ikatodon/ansible/group_vars/all.yml
+++ b/ikatodon/ansible/group_vars/all.yml
@@ -1,0 +1,6 @@
+# 実機確認で得た値をここで上書きする（ikatodon/ansible/roles/mastodon/defaults/main.yml 参照）。
+#
+#   docker inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' <稼働中コンテナ名>
+#
+# mastodon_compose_project_name: <ここに実機確認結果を書く>
+{}

--- a/ikatodon/ansible/host_vars/web1.yml
+++ b/ikatodon/ansible/host_vars/web1.yml
@@ -1,0 +1,8 @@
+# mastodon_private_ip はプライベート IP であり、このファイルには平文で書かない
+# （CLAUDE.md 方針・infrastructure.md 参照）。ansible-vault で値単位に暗号化した
+# ブロックをここへ追記すること。
+#
+#   ansible-vault encrypt_string --ask-vault-pass '<PRIVATE_IP>' --name 'mastodon_private_ip'
+#
+# 出力される `mastodon_private_ip: !vault | ...` のブロックをそのままここに貼り付ける。
+{}

--- a/ikatodon/ansible/host_vars/web2.yml
+++ b/ikatodon/ansible/host_vars/web2.yml
@@ -1,0 +1,8 @@
+# mastodon_private_ip はプライベート IP であり、このファイルには平文で書かない
+# （CLAUDE.md 方針・infrastructure.md 参照）。ansible-vault で値単位に暗号化した
+# ブロックをここへ追記すること。
+#
+#   ansible-vault encrypt_string --ask-vault-pass '<PRIVATE_IP>' --name 'mastodon_private_ip'
+#
+# 出力される `mastodon_private_ip: !vault | ...` のブロックをそのままここに貼り付ける。
+{}

--- a/ikatodon/ansible/playbooks/deploy.yml
+++ b/ikatodon/ansible/playbooks/deploy.yml
@@ -1,0 +1,14 @@
+---
+# デプロイ (= ロールバックも同じ)。ikatodon_version に前バージョンのタグ名を渡せば
+# ロールバックになる。専用の切り戻し経路は持たない (infrastructure.md 参照)。
+#
+#   ansible-playbook playbooks/deploy.yml -e "ikatodon_version=v4.6.5"
+#
+# serial: 1 で1台ずつ処理する。現状は checkout・override 配布・.env.production 配布・
+# pull までを実装している。up -d・ヘルスチェック・nginx 切替は後続の PR で追加する。
+
+- name: Deploy ikatodon
+  hosts: all
+  serial: 1
+  roles:
+    - mastodon

--- a/ikatodon/ansible/roles/mastodon/defaults/main.yml
+++ b/ikatodon/ansible/roles/mastodon/defaults/main.yml
@@ -1,0 +1,8 @@
+# 実機の稼働中コンテナに対して次のコマンドで確認し、group_vars/all.yml で上書きすること
+# （infrastructure.md 10節参照）。
+#
+#   docker inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' <稼働中コンテナ名>
+#
+mastodon_compose_project_name: CHANGEME_confirm_on_the_real_host
+
+mastodon_dir: /home/mastodon/live

--- a/ikatodon/ansible/roles/mastodon/tasks/main.yml
+++ b/ikatodon/ansible/roles/mastodon/tasks/main.yml
@@ -9,6 +9,20 @@
       ikatodon_version が指定されていません。
       -e "ikatodon_version=<タグ名>" で渡してください。
 
+- name: Require deployment variables to be configured
+  # 未投入のまま実行すると、mastodon_private_ip はテンプレート展開時に (checkout の後で)
+  # 失敗し、mastodon_compose_project_name はプレースホルダーのまま稼働中イメージとの
+  # 整合性チェック (下記) を素通りしてしまう。作業ツリーを触る前にここで止める。
+  ansible.builtin.assert:
+    that:
+      - mastodon_private_ip is defined
+      - mastodon_private_ip | length > 0
+      - mastodon_compose_project_name is defined
+      - not mastodon_compose_project_name.startswith('CHANGEME_')
+    fail_msg: >-
+      mastodon_private_ip または mastodon_compose_project_name が未設定です。
+      実機の値を host_vars / group_vars へ投入してください (deploy-runbook.md 参照)。
+
 - name: Fail if the working tree is dirty
   ansible.builtin.command: git status --porcelain
   args:

--- a/ikatodon/ansible/roles/mastodon/tasks/main.yml
+++ b/ikatodon/ansible/roles/mastodon/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+# checkout・override 配布・.env.production 配布・pull まで。
+# up -d とヘルスチェック、nginx との切替は nginx role (後続 PR) で行う。
+
+- name: Require ikatodon_version
+  ansible.builtin.assert:
+    that: ikatodon_version is defined and ikatodon_version | length > 0
+    fail_msg: >-
+      ikatodon_version が指定されていません。
+      -e "ikatodon_version=<タグ名>" で渡してください。
+
+- name: Fail if the working tree is dirty
+  ansible.builtin.command: git status --porcelain
+  args:
+    chdir: '{{ mastodon_dir }}'
+  register: ikatodon_git_status
+  changed_when: false
+
+- name: Abort when local changes exist
+  ansible.builtin.fail:
+    msg: >-
+      {{ mastodon_dir }} の作業ツリーに未コミットの変更があります。
+      手作業の内容を失わないため、強制的な上書きはせず中断します。
+  when: ikatodon_git_status.stdout | length > 0
+
+- name: Fetch tags
+  ansible.builtin.command: git fetch --tags
+  args:
+    chdir: '{{ mastodon_dir }}'
+  changed_when: true
+
+- name: Get the currently checked-out tag
+  ansible.builtin.command: git describe --tags --exact-match
+  args:
+    chdir: '{{ mastodon_dir }}'
+  register: ikatodon_current_tag
+  changed_when: false
+  failed_when: false
+
+- name: Get the running container image tag
+  ansible.builtin.command: >-
+    docker inspect --format '{{ '{{' }} index .Config.Image {{ '}}' }}'
+    {{ mastodon_compose_project_name }}-web-1
+  register: ikatodon_running_image
+  changed_when: false
+  failed_when: false
+
+- name: Abort if the clone tag and the running image disagree
+  # 前回のデプロイが中途半端に終わった証拠のため、その上に重ねない。
+  # 初回デプロイ等でどちらかが取得できない場合はこのチェックを飛ばす。
+  ansible.builtin.fail:
+    msg: >-
+      作業ツリーのタグ ({{ ikatodon_current_tag.stdout }}) と稼働中イメージ
+      ({{ ikatodon_running_image.stdout }}) が一致しません。中断します。
+  when:
+    - ikatodon_current_tag.stdout | length > 0
+    - ikatodon_running_image.stdout | length > 0
+    - not ikatodon_running_image.stdout.endswith(':' + ikatodon_current_tag.stdout)
+
+- name: Checkout the target version
+  ansible.builtin.command: 'git checkout {{ ikatodon_version }}'
+  args:
+    chdir: '{{ mastodon_dir }}'
+  changed_when: true
+
+- name: Deploy docker-compose.override.yml
+  ansible.builtin.template:
+    src: docker-compose.override.yml.j2
+    dest: '{{ mastodon_dir }}/docker-compose.override.yml'
+    owner: mastodon
+    group: mastodon
+    mode: '0640'
+
+- name: Rotate .env.production backups
+  ansible.builtin.shell: |
+    set -e
+    cd {{ mastodon_dir | quote }}
+    if [ -f .env.production ]; then
+      if [ -f .env.production.bak.1 ]; then
+        cp -p .env.production.bak.1 .env.production.bak.2
+      fi
+      cp -p .env.production .env.production.bak.1
+    fi
+  changed_when: false
+
+- name: Deploy .env.production
+  ansible.builtin.copy:
+    content: "{{ lookup('ansible.builtin.env', 'IKATODON_ENV_PRODUCTION') }}"
+    dest: '{{ mastodon_dir }}/.env.production'
+    owner: mastodon
+    group: mastodon
+    mode: '0600'
+  no_log: true
+
+- name: Pull images
+  ansible.builtin.command: docker compose pull
+  args:
+    chdir: '{{ mastodon_dir }}'
+  changed_when: true

--- a/ikatodon/ansible/roles/mastodon/templates/docker-compose.override.yml.j2
+++ b/ikatodon/ansible/roles/mastodon/templates/docker-compose.override.yml.j2
@@ -1,0 +1,10 @@
+{# ホストごとに値が違うもの1つだけをここに足す（インフラドキュメント参照）。
+   ports はシーケンスなので base の 127.0.0.1:3000:3000 に追記される。
+   peer fallback (隣サーバーへのゼロダウンタイム切替) のためだけに必要。 #}
+services:
+  web:
+    ports:
+      - '{{ mastodon_private_ip }}:3000:3000'
+  streaming:
+    ports:
+      - '{{ mastodon_private_ip }}:4000:4000'


### PR DESCRIPTION
issue #876 のデプロイ自動化 (3/5)。#894 の上に積む。

checkout（作業ツリー clean 検証・タグと稼働中イメージの一致確認込み）、`docker-compose.override.yml` の配布（peer fallback 用のプライベート IP publish のみ）、`.env.production` の配布（2世代バックアップ・`no_log`）、`docker compose pull` までを Ansible の mastodon role として実装した。up -d・ヘルスチェック・nginx との切替は後続の PR (nginx role) で追加する。

`COMPOSE_PROJECT_NAME` とプライベート IP は実機確認が必要なためプレースホルダーのままにしてある。プライベート IP は ansible-vault で値単位に暗号化する前提で host_vars に置き場所だけ用意した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated deployment and rollback support by selecting a release version.
  * Added deployment steps for checking out releases, distributing production configuration, backing up existing files, and pulling container images.
  * Added network configuration for web and streaming services on private host addresses.

* **Documentation**
  * Documented deployment progress, host-specific settings, and secure storage requirements for private IP values.
  * Added guidance for identifying and overriding the active Compose project name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->