### PR TITLE
ikatodon: Ansible nginx role とゼロダウンタイム切替、migration、dry_run を追加

### DIFF
--- a/.github/workflows/ikatodon-deploy.yml
+++ b/.github/workflows/ikatodon-deploy.yml
@@ -1,9 +1,7 @@
 name: Deploy ikatodon
 
-# 本番 Web サーバーへのデプロイ (issue #876)。
-#
-# 現状は Phase 2 (存在確認・ssh 到達性確認・checkout・.env.production 配布・pull) まで
-# 実装している。up -d・ヘルスチェック・nginx との切替は後続の PR (nginx role) で追加する。
+# 本番 Web サーバーへのデプロイ (issue #876)。ロールバックも同じワークフローを前バージョンの
+# タグで実行するだけで、専用の切り戻し経路は持たない (infrastructure.md 参照)。
 #
 # セルフホストランナーは使わない (このフォークはパブリックリポジトリで、フォークからの PR で
 # 任意コードがサーバー上で実行され得るため)。
@@ -15,6 +13,11 @@ on:
         description: 'デプロイ対象のタグ名 (例: v4.6.5, v4.6.5.1)'
         required: true
         type: string
+      dry_run:
+        description: 'checkout・override 配布・.env.production 配布・pull までで打ち切る (本番への影響なし)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -29,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       VERSION: ${{ inputs.version }}
+      DRY_RUN: ${{ inputs.dry_run }}
     steps:
       - name: Check that this is run by the repository owner
         env:
@@ -82,6 +86,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Ansible ssh access
@@ -105,13 +110,52 @@ jobs:
           set -euo pipefail
           ansible all -m ping --private-key ~/.ssh/ikatodon_deploy --vault-password-file ~/.ansible_vault_pass
 
-      - name: Run the mastodon role (checkout, override, .env.production, pull)
+      - name: Determine current versions and whether migrations are needed
+        id: migrations
+        working-directory: ikatodon/ansible
+        run: |
+          set -euo pipefail
+
+          get_tag() {
+            local host_alias="$1" user ip
+            user="$(yq ".all.hosts.${host_alias}.ansible_user" inventory/hosts.yml)"
+            ip="$(yq ".all.hosts.${host_alias}.ansible_host" inventory/hosts.yml)"
+            ssh -o StrictHostKeyChecking=yes -i ~/.ssh/ikatodon_deploy "${user}@${ip}" \
+              'git -C /home/mastodon/live describe --tags --exact-match' 2>/dev/null || true
+          }
+
+          tag1="$(get_tag web1)"
+          tag2="$(get_tag web2)"
+
+          if [ -n "${tag1}" ] && [ -n "${tag2}" ] && [ "${tag1}" != "${tag2}" ]; then
+            echo "::error::2台の稼働バージョンが一致しません (web1: ${tag1}, web2: ${tag2})。前回のデプロイが中途半端に終わっている可能性があるため中断します"
+            exit 1
+          fi
+
+          current_tag="${tag1:-${tag2}}"
+          if [ -z "${current_tag}" ]; then
+            echo "::notice::稼働中バージョンを取得できませんでした (初回デプロイ等)。安全側として migration を実行します"
+            echo "run_migrations=true" >>"$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          cd ../..
+          if git diff --quiet "${current_tag}" "${VERSION}" -- db/migrate db/post_migrate; then
+            echo "run_migrations=false" >>"$GITHUB_OUTPUT"
+          else
+            echo "run_migrations=true" >>"$GITHUB_OUTPUT"
+          fi
+
+      - name: Run the deploy playbook
         working-directory: ikatodon/ansible
         env:
           IKATODON_ENV_PRODUCTION: ${{ secrets.IKATODON_ENV_PRODUCTION }}
+          RUN_MIGRATIONS: ${{ steps.migrations.outputs.run_migrations }}
         run: |
           set -euo pipefail
           ansible-playbook playbooks/deploy.yml \
             --private-key ~/.ssh/ikatodon_deploy \
             --vault-password-file ~/.ansible_vault_pass \
-            -e "ikatodon_version=${VERSION}"
+            -e "ikatodon_version=${VERSION}" \
+            -e "dry_run=${DRY_RUN}" \
+            -e "run_migrations=${RUN_MIGRATIONS}"

--- a/.github/workflows/ikatodon-nginx.yml
+++ b/.github/workflows/ikatodon-nginx.yml
@@ -1,0 +1,68 @@
+name: Apply nginx configuration
+
+# nginx 設定の適用 (issue #876)。デプロイとは独立に、稀に実行する
+# (nginx-audit.md の棚卸しに基づく修正・vhost 定義の変更時など)。
+#
+# セルフホストランナーは使わない (このフォークはパブリックリポジトリで、フォークからの PR で
+# 任意コードがサーバー上で実行され得るため)。
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: '--check --diff で差分だけ確認し、実際には適用しない'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ikatodon-nginx
+  cancel-in-progress: false
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that required secrets are set
+        env:
+          SSH_KEY_SET: ${{ secrets.IKATODON_DEPLOY_SSH_KEY != '' }}
+          KNOWN_HOSTS_SET: ${{ secrets.IKATODON_DEPLOY_KNOWN_HOSTS != '' }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ "${SSH_KEY_SET}" = "true" ] || missing+=(IKATODON_DEPLOY_SSH_KEY)
+          [ "${KNOWN_HOSTS_SET}" = "true" ] || missing+=(IKATODON_DEPLOY_KNOWN_HOSTS)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "::error::未設定の secrets があります: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Ansible ssh access
+        env:
+          SSH_KEY: ${{ secrets.IKATODON_DEPLOY_SSH_KEY }}
+          KNOWN_HOSTS: ${{ secrets.IKATODON_DEPLOY_KNOWN_HOSTS }}
+        run: |
+          set -euo pipefail
+          umask 077
+          mkdir -p ~/.ssh
+          printf '%s\n' "${SSH_KEY}" > ~/.ssh/ikatodon_deploy
+          printf '%s\n' "${KNOWN_HOSTS}" > ~/.ssh/known_hosts
+          chmod 600 ~/.ssh/ikatodon_deploy ~/.ssh/known_hosts
+
+      - name: Apply nginx configuration
+        working-directory: ikatodon/ansible
+        env:
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          args=(playbooks/nginx.yml --private-key ~/.ssh/ikatodon_deploy)
+          if [ "${DRY_RUN}" = "true" ]; then
+            args+=(--check --diff)
+          fi
+          ansible-playbook "${args[@]}"

--- a/.github/workflows/ikatodon-nginx.yml
+++ b/.github/workflows/ikatodon-nginx.yml
@@ -26,15 +26,27 @@ jobs:
   apply:
     runs-on: ubuntu-latest
     steps:
+      - name: Check that this is run by the repository owner
+        env:
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          if [ "${ACTOR}" != "koba-lab" ]; then
+            echo "::error::このワークフローはリポジトリオーナーのみ実行できます (actor: ${ACTOR})"
+            exit 1
+          fi
+
       - name: Check that required secrets are set
         env:
           SSH_KEY_SET: ${{ secrets.IKATODON_DEPLOY_SSH_KEY != '' }}
           KNOWN_HOSTS_SET: ${{ secrets.IKATODON_DEPLOY_KNOWN_HOSTS != '' }}
+          VAULT_PASSWORD_SET: ${{ secrets.IKATODON_ANSIBLE_VAULT_PASSWORD != '' }}
         run: |
           set -euo pipefail
           missing=()
           [ "${SSH_KEY_SET}" = "true" ] || missing+=(IKATODON_DEPLOY_SSH_KEY)
           [ "${KNOWN_HOSTS_SET}" = "true" ] || missing+=(IKATODON_DEPLOY_KNOWN_HOSTS)
+          [ "${VAULT_PASSWORD_SET}" = "true" ] || missing+=(IKATODON_ANSIBLE_VAULT_PASSWORD)
           if [ "${#missing[@]}" -gt 0 ]; then
             echo "::error::未設定の secrets があります: ${missing[*]}"
             exit 1
@@ -42,11 +54,14 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Set up Ansible ssh access
         env:
           SSH_KEY: ${{ secrets.IKATODON_DEPLOY_SSH_KEY }}
           KNOWN_HOSTS: ${{ secrets.IKATODON_DEPLOY_KNOWN_HOSTS }}
+          VAULT_PASSWORD: ${{ secrets.IKATODON_ANSIBLE_VAULT_PASSWORD }}
         run: |
           set -euo pipefail
           umask 077
@@ -54,6 +69,8 @@ jobs:
           printf '%s\n' "${SSH_KEY}" > ~/.ssh/ikatodon_deploy
           printf '%s\n' "${KNOWN_HOSTS}" > ~/.ssh/known_hosts
           chmod 600 ~/.ssh/ikatodon_deploy ~/.ssh/known_hosts
+          printf '%s\n' "${VAULT_PASSWORD}" > ~/.ansible_vault_pass
+          chmod 600 ~/.ansible_vault_pass
 
       - name: Apply nginx configuration
         working-directory: ikatodon/ansible
@@ -61,7 +78,7 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           set -euo pipefail
-          args=(playbooks/nginx.yml --private-key ~/.ssh/ikatodon_deploy)
+          args=(playbooks/nginx.yml --private-key ~/.ssh/ikatodon_deploy --vault-password-file ~/.ansible_vault_pass)
           if [ "${DRY_RUN}" = "true" ]; then
             args+=(--check --diff)
           fi

--- a/ikatodon/ansible/group_vars/all.yml
+++ b/ikatodon/ansible/group_vars/all.yml
@@ -1,6 +1,8 @@
+# mastodon / nginx 両 role が参照する共通の値。
+mastodon_dir: /home/mastodon/live
+
 # 実機確認で得た値をここで上書きする（ikatodon/ansible/roles/mastodon/defaults/main.yml 参照）。
 #
 #   docker inspect --format '{{ index .Config.Labels "com.docker.compose.project" }}' <稼働中コンテナ名>
 #
 # mastodon_compose_project_name: <ここに実機確認結果を書く>
-{}

--- a/ikatodon/ansible/playbooks/deploy.yml
+++ b/ikatodon/ansible/playbooks/deploy.yml
@@ -41,43 +41,63 @@
       changed_when: true
 
     - name: Drain this host
+      # nginx の設定ファイル操作・reload は root が要る。mastodon role 側は
+      # become を付けていない (.env.production 等の所有者が mastodon のまま必要なため)。
       ansible.builtin.include_tasks: ../roles/nginx/tasks/drain.yml
+      become: true
 
-    - name: Start containers
-      ansible.builtin.command: docker compose up -d
-      args:
-        chdir: '{{ mastodon_dir }}'
-      changed_when: true
+    - name: Replace and verify containers, then undrain
+      # block 内のどこかで失敗すると、rescue がこのホストを drain されたままにして
+      # 明示的に止める。ここで自動的に undrain しない理由は、壊れた可能性のある
+      # コンテナへトラフィックを戻すのは drain されたまま (= 隣ホストが全量を受けて
+      # サービス継続) より悪化させ得るため。復旧するまで隣ホストが全量を受ける。
+      block:
+        - name: Start containers
+          ansible.builtin.command: docker compose up -d
+          args:
+            chdir: '{{ mastodon_dir }}'
+          changed_when: true
 
-    - name: Wait for the web health check
-      ansible.builtin.uri:
-        url: http://127.0.0.1:3000/health
-        status_code: 200
-      register: ikatodon_web_health
-      until: ikatodon_web_health.status | default(0) == 200
-      retries: 30
-      delay: 2
+        - name: Wait for the web health check
+          ansible.builtin.uri:
+            url: http://127.0.0.1:3000/health
+            status_code: 200
+          register: ikatodon_web_health
+          until: ikatodon_web_health.status | default(0) == 200
+          retries: 30
+          delay: 2
 
-    - name: Wait for the streaming health check
-      ansible.builtin.uri:
-        url: http://127.0.0.1:4000/api/v1/streaming/health
-        status_code: 200
-      register: ikatodon_streaming_health
-      until: ikatodon_streaming_health.status | default(0) == 200
-      retries: 30
-      delay: 2
+        - name: Wait for the streaming health check
+          ansible.builtin.uri:
+            url: http://127.0.0.1:4000/api/v1/streaming/health
+            status_code: 200
+          register: ikatodon_streaming_health
+          until: ikatodon_streaming_health.status | default(0) == 200
+          retries: 30
+          delay: 2
 
-    - name: Check that sidekiq is running
-      ansible.builtin.command: docker compose ps sidekiq --format '{{ '{{' }}.State{{ '}}' }}'
-      args:
-        chdir: '{{ mastodon_dir }}'
-      register: ikatodon_sidekiq_state
-      changed_when: false
-      failed_when: "'running' not in ikatodon_sidekiq_state.stdout"
+        - name: Check that sidekiq is running
+          ansible.builtin.command: docker compose ps sidekiq --format '{{ '{{' }}.State{{ '}}' }}'
+          args:
+            chdir: '{{ mastodon_dir }}'
+          register: ikatodon_sidekiq_state
+          changed_when: false
+          failed_when: "'running' not in ikatodon_sidekiq_state.stdout"
 
-    - name: Undrain this host
-      # playbook は必ずここまで到達し、drain したまま終了する経路を作らない。
-      ansible.builtin.include_tasks: ../roles/nginx/tasks/undrain.yml
+        - name: Undrain this host
+          # playbook はここまで到達できて初めて undrain する。失敗時に自動で
+          # undrain する経路は意図的に作らない (block のコメント参照)。
+          ansible.builtin.include_tasks: ../roles/nginx/tasks/undrain.yml
+          become: true
+      rescue:
+        - name: Fail with recovery instructions
+          ansible.builtin.fail:
+            msg: >-
+              {{ inventory_hostname }} はコンテナの入替またはヘルスチェックに失敗し、
+              drain されたままです (nginx から外れており、隣ホストが全トラフィックを
+              受けています)。このホストは自動では undrain しません。ログを確認し、
+              deploy-runbook.md の「ヘルスチェックが通らない」を参照して手動で復旧
+              してください。
 
 - name: Run post-deployment migrations
   hosts: "{{ groups['all'][0] }}"

--- a/ikatodon/ansible/playbooks/deploy.yml
+++ b/ikatodon/ansible/playbooks/deploy.yml
@@ -2,13 +2,92 @@
 # デプロイ (= ロールバックも同じ)。ikatodon_version に前バージョンのタグ名を渡せば
 # ロールバックになる。専用の切り戻し経路は持たない (infrastructure.md 参照)。
 #
-#   ansible-playbook playbooks/deploy.yml -e "ikatodon_version=v4.6.5"
+#   ansible-playbook playbooks/deploy.yml \
+#     -e "ikatodon_version=v4.6.5" \
+#     -e "run_migrations=true" \
+#     -e "dry_run=false"
 #
-# serial: 1 で1台ずつ処理する。現状は checkout・override 配布・.env.production 配布・
-# pull までを実装している。up -d・ヘルスチェック・nginx 切替は後続の PR で追加する。
+# serial: 1 で1台ずつ処理する。1台ごとに drain → up -d → ヘルスチェック → undrain の
+# 順で進め、undrain まで終えてから次のホストに移る。dry_run=true のときは checkout・
+# override 配布・.env.production 配布・pull までで打ち切る (本番への影響がない範囲)。
+#
+# migration は pre (SKIP_POST_DEPLOYMENT_MIGRATIONS=true) → 全台入替 → post の順で
+# 実行する。要否は呼び出し側 (GitHub Actions) が判定して run_migrations に渡す。
 
 - name: Deploy ikatodon
   hosts: all
   serial: 1
+  vars:
+    dry_run: false
+    run_migrations: false
+  pre_tasks:
+    - name: Determine whether this host is first in this run
+      ansible.builtin.set_fact:
+        ikatodon_is_first_host: '{{ inventory_hostname == ansible_play_hosts_all[0] }}'
   roles:
     - mastodon
+  tasks:
+    - name: Stop here for a dry run
+      ansible.builtin.meta: end_play
+      when: dry_run | bool
+
+    - name: Run pre-deployment migrations (first host only)
+      ansible.builtin.command: >-
+        docker compose run --rm web
+        env SKIP_POST_DEPLOYMENT_MIGRATIONS=true bundle exec rails db:migrate
+      args:
+        chdir: '{{ mastodon_dir }}'
+      when: run_migrations | bool and ikatodon_is_first_host
+      changed_when: true
+
+    - name: Drain this host
+      ansible.builtin.include_tasks: ../roles/nginx/tasks/drain.yml
+
+    - name: Start containers
+      ansible.builtin.command: docker compose up -d
+      args:
+        chdir: '{{ mastodon_dir }}'
+      changed_when: true
+
+    - name: Wait for the web health check
+      ansible.builtin.uri:
+        url: http://127.0.0.1:3000/health
+        status_code: 200
+      register: ikatodon_web_health
+      until: ikatodon_web_health.status | default(0) == 200
+      retries: 30
+      delay: 2
+
+    - name: Wait for the streaming health check
+      ansible.builtin.uri:
+        url: http://127.0.0.1:4000/api/v1/streaming/health
+        status_code: 200
+      register: ikatodon_streaming_health
+      until: ikatodon_streaming_health.status | default(0) == 200
+      retries: 30
+      delay: 2
+
+    - name: Check that sidekiq is running
+      ansible.builtin.command: docker compose ps sidekiq --format '{{ '{{' }}.State{{ '}}' }}'
+      args:
+        chdir: '{{ mastodon_dir }}'
+      register: ikatodon_sidekiq_state
+      changed_when: false
+      failed_when: "'running' not in ikatodon_sidekiq_state.stdout"
+
+    - name: Undrain this host
+      # playbook は必ずここまで到達し、drain したまま終了する経路を作らない。
+      ansible.builtin.include_tasks: ../roles/nginx/tasks/undrain.yml
+
+- name: Run post-deployment migrations
+  hosts: "{{ groups['all'][0] }}"
+  vars:
+    dry_run: false
+    run_migrations: false
+  tasks:
+    - name: Run post-deployment migrations (first host only, after all hosts are updated)
+      ansible.builtin.command: docker compose run --rm web bundle exec rails db:migrate
+      args:
+        chdir: '{{ mastodon_dir }}'
+      when: run_migrations | bool and not (dry_run | bool)
+      changed_when: true

--- a/ikatodon/ansible/playbooks/nginx.yml
+++ b/ikatodon/ansible/playbooks/nginx.yml
@@ -6,5 +6,6 @@
 
 - name: Apply nginx configuration
   hosts: all
+  become: true
   roles:
     - nginx

--- a/ikatodon/ansible/playbooks/nginx.yml
+++ b/ikatodon/ansible/playbooks/nginx.yml
@@ -1,0 +1,10 @@
+---
+# nginx 設定の適用（棚卸しに基づく修正・upstream 導入）。稀にしか実行しない。
+# デプロイのたびに実行する drain / undrain は deploy.yml 側で行う。
+#
+#   ansible-playbook playbooks/nginx.yml [--check --diff]
+
+- name: Apply nginx configuration
+  hosts: all
+  roles:
+    - nginx

--- a/ikatodon/ansible/roles/mastodon/defaults/main.yml
+++ b/ikatodon/ansible/roles/mastodon/defaults/main.yml
@@ -5,4 +5,4 @@
 #
 mastodon_compose_project_name: CHANGEME_confirm_on_the_real_host
 
-mastodon_dir: /home/mastodon/live
+# mastodon_dir は nginx role からも参照する共通の値のため group_vars/all.yml で定義する。

--- a/ikatodon/ansible/roles/nginx/defaults/main.yml
+++ b/ikatodon/ansible/roles/nginx/defaults/main.yml
@@ -1,0 +1,6 @@
+ikatodon_server_name: ika.queloud.net
+
+# メンテナンスモード中のアクセスを許可する IP。実機の geo $allow_ip から移すこと
+# （nginx-audit.md 2.4節）。プライベート IP と同様に公開したくない場合は
+# ansible-vault で値単位に暗号化する。
+ikatodon_maintenance_allow_ips: []

--- a/ikatodon/ansible/roles/nginx/handlers/main.yml
+++ b/ikatodon/ansible/roles/nginx/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload nginx
+  ansible.builtin.systemd:
+    name: nginx
+    state: reloaded

--- a/ikatodon/ansible/roles/nginx/tasks/drain.yml
+++ b/ikatodon/ansible/roles/nginx/tasks/drain.yml
@@ -1,0 +1,20 @@
+---
+# 自ホストを upstream から外し、隣サーバーへ全量流す。
+# symlink の張り替えなので切替は一瞬。streaming の WebSocket は再接続が発生する
+# (構造上ゼロにできない)。
+
+- name: Switch the upstream snippet to drain
+  ansible.builtin.file:
+    src: /etc/nginx/snippets/ikatodon-upstream-drain.conf
+    dest: /etc/nginx/snippets/ikatodon-upstream.conf
+    state: link
+    force: true
+
+- name: Validate nginx configuration
+  ansible.builtin.command: nginx -t
+  changed_when: false
+
+- name: Reload nginx
+  ansible.builtin.systemd:
+    name: nginx
+    state: reloaded

--- a/ikatodon/ansible/roles/nginx/tasks/main.yml
+++ b/ikatodon/ansible/roles/nginx/tasks/main.yml
@@ -3,6 +3,17 @@
 # 稀にしか実行しない (playbooks/nginx.yml から呼ぶ)。drain / undrain は別タスク
 # ファイル (drain.yml / undrain.yml) で、デプロイのたびに実行する。
 
+- name: Require ikatodon_maintenance_allow_ips to be configured
+  # 既定値の空リストのまま適用すると geo $allow_ip が空になり、メンテナンスモード中に
+  # オーナー自身を含む全員が 503 になる。maintenance.html を消す以外に解除手段が無くなる
+  # ため、投入し忘れたままの適用を明示的に拒否する。
+  ansible.builtin.assert:
+    that: ikatodon_maintenance_allow_ips | length > 0
+    fail_msg: >-
+      ikatodon_maintenance_allow_ips が空です。メンテナンスモード中に誰もアクセス
+      できなくなるため中断します。実機の geo $allow_ip の値を投入してください
+      (deploy-runbook.md 参照)。
+
 - name: Determine the peer host's private IP
   ansible.builtin.set_fact:
     ikatodon_peer_private_ip: "{{ hostvars[groups['all'] | difference([inventory_hostname]) | first]['mastodon_private_ip'] }}"

--- a/ikatodon/ansible/roles/nginx/tasks/main.yml
+++ b/ikatodon/ansible/roles/nginx/tasks/main.yml
@@ -1,0 +1,61 @@
+---
+# サイト設定と upstream snippets の配布。棚卸し (nginx-audit.md) に基づく修正を含む。
+# 稀にしか実行しない (playbooks/nginx.yml から呼ぶ)。drain / undrain は別タスク
+# ファイル (drain.yml / undrain.yml) で、デプロイのたびに実行する。
+
+- name: Determine the peer host's private IP
+  ansible.builtin.set_fact:
+    ikatodon_peer_private_ip: "{{ hostvars[groups['all'] | difference([inventory_hostname]) | first]['mastodon_private_ip'] }}"
+
+- name: Deploy the vhost
+  ansible.builtin.template:
+    src: site.conf.j2
+    dest: /etc/nginx/sites-available/{{ ikatodon_server_name }}
+    owner: root
+    group: root
+    mode: '0644'
+  notify: reload nginx
+
+- name: Ensure the vhost is enabled
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/{{ ikatodon_server_name }}
+    dest: /etc/nginx/sites-enabled/{{ ikatodon_server_name }}
+    state: link
+
+- name: Remove the retired test vhost (nginx-audit.md 2.8)
+  ansible.builtin.file:
+    path: '{{ item }}'
+    state: absent
+  loop:
+    - /etc/nginx/sites-enabled/test.ika.queloud.net
+    - /etc/nginx/sites-available/test.ika.queloud.net
+  notify: reload nginx
+
+- name: Deploy the normal upstream snippet
+  ansible.builtin.template:
+    src: upstream-normal.conf.j2
+    dest: /etc/nginx/snippets/ikatodon-upstream-normal.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: reload nginx
+
+- name: Deploy the drain upstream snippet
+  ansible.builtin.template:
+    src: upstream-drain.conf.j2
+    dest: /etc/nginx/snippets/ikatodon-upstream-drain.conf
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Point the upstream snippet symlink at "normal" unless it already exists
+  # drain 中に誤って normal へ戻さないよう、既にリンクがあれば触らない。
+  ansible.builtin.file:
+    src: /etc/nginx/snippets/ikatodon-upstream-normal.conf
+    dest: /etc/nginx/snippets/ikatodon-upstream.conf
+    state: link
+    force: false
+
+- name: Validate nginx configuration
+  ansible.builtin.command: nginx -t
+  changed_when: false

--- a/ikatodon/ansible/roles/nginx/tasks/undrain.yml
+++ b/ikatodon/ansible/roles/nginx/tasks/undrain.yml
@@ -1,0 +1,19 @@
+---
+# drain を解除し、自ホストを upstream へ戻す。
+# playbook は必ずこのタスクで通常状態に戻して終える (drain したまま終了する経路を作らない)。
+
+- name: Switch the upstream snippet to normal
+  ansible.builtin.file:
+    src: /etc/nginx/snippets/ikatodon-upstream-normal.conf
+    dest: /etc/nginx/snippets/ikatodon-upstream.conf
+    state: link
+    force: true
+
+- name: Validate nginx configuration
+  ansible.builtin.command: nginx -t
+  changed_when: false
+
+- name: Reload nginx
+  ansible.builtin.systemd:
+    name: nginx
+    state: reloaded

--- a/ikatodon/ansible/roles/nginx/templates/site.conf.j2
+++ b/ikatodon/ansible/roles/nginx/templates/site.conf.j2
@@ -1,0 +1,166 @@
+{# nginx-audit.md の棚卸しに基づく修正を反映したテンプレート。
+   現行設定との差分:
+   - server_name default_server; の誤指定を listen 80 default_server; に修正 (2.1・2.2)
+   - upstream ikatodon_web / ikatodon_streaming 経由にし、peer fallback を導入 (2.9)
+   - error_page を相対 URI に統一 (2.6)
+   - ssl_protocols を TLSv1.2 TLSv1.3 に、cipher を Mozilla Intermediate 相当に更新 (2.7)
+   - client_max_body_size 99m、proxy_read_timeout 120 を上流サンプルに合わせて追加
+   - acme-challenge upstream は inventory のホストのみ (応答のない2 IP は含まれなくなる。2.3)
+#}
+# Lets Encrypt更新用
+upstream acme-challenge {
+{% for host in groups['all'] %}
+  server {{ hostvars[host].ansible_host }}:80;
+{% endfor %}
+}
+
+# drain 切替の対象。normal / drain の2種類のテンプレートを生成し、このファイルへの
+# symlink を張り替えることで切り替える (deploy.yml 参照)。
+include /etc/nginx/snippets/ikatodon-upstream.conf;
+
+map $http_upgrade $connection_upgrade {
+  default upgrade;
+  ''      close;
+}
+
+geo $allow_ip {
+  default disable;
+{% for ip in ikatodon_maintenance_allow_ips %}
+  {{ ip }} allow;
+{% endfor %}
+}
+
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+  server_name {{ ikatodon_server_name }};
+  root {{ mastodon_dir }}/public;
+
+  # Useful for Let's Encrypt
+  location ^~ /.well-known/acme-challenge/ {
+    root /home/mastodon/letsencrypt;
+    try_files $uri @acme-challenge;
+  }
+
+  # lets encrypt証明書更新
+  location @acme-challenge {
+    proxy_set_header Connection "";
+    proxy_set_header HOST $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_pass http://acme-challenge;
+    proxy_next_upstream http_404;
+    proxy_intercept_errors on;
+  }
+
+  location / { return 301 https://$host$request_uri; }
+}
+
+server {
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name {{ ikatodon_server_name }};
+
+  ssl_protocols TLSv1.2 TLSv1.3;
+  ssl_ciphers ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384:DHE-RSA-CHACHA20-POLY1305;
+  ssl_prefer_server_ciphers on;
+  ssl_session_cache shared:SSL:10m;
+  ssl_session_tickets off;
+
+  ssl_certificate     /etc/letsencrypt/live/{{ ikatodon_server_name }}/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/{{ ikatodon_server_name }}/privkey.pem;
+
+  keepalive_timeout    70;
+  sendfile             on;
+  client_max_body_size 99m;
+  proxy_read_timeout   120;
+
+  root {{ mastodon_dir }}/public;
+
+  gzip on;
+  gzip_disable "msie6";
+  gzip_vary on;
+  gzip_proxied any;
+  gzip_comp_level 6;
+  gzip_buffers 16 8k;
+  gzip_http_version 1.1;
+  gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+  # HSTS はアプリ側からも送られており2本重複しているが (nginx-audit.md 2.5)、
+  # アプリ側の設定変更を伴う判断のため、今回は現状の値を維持し対応を見送る。
+  add_header Strict-Transport-Security "max-age=31536000";
+
+  location / {
+    try_files $uri @proxy;
+  }
+
+  location ~ ^/(emoji|packs|system/accounts/avatars|system/media_attachments/files) {
+    add_header Cache-Control "public, max-age=31536000, immutable";
+    try_files $uri @proxy;
+  }
+
+  location /sw.js {
+    add_header Cache-Control "public, max-age=0";
+    try_files $uri @proxy;
+  }
+
+  location @proxy {
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Proxy "";
+    proxy_pass_header Server;
+
+    proxy_pass http://ikatodon_web;
+    proxy_buffering off;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    tcp_nodelay on;
+  }
+
+  location /api/v1/streaming {
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto https;
+    proxy_set_header Proxy "";
+
+    proxy_pass http://ikatodon_streaming;
+    proxy_buffering off;
+    proxy_redirect off;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection $connection_upgrade;
+
+    tcp_nodelay on;
+  }
+
+  location /ikatodon-media/ {
+    rewrite ^/ikatodon-media/(.*)$ https://files-ika.queloud.net/$1 permanent;
+  }
+
+  error_page 500 501 502 504 /500.html;
+  error_page 503 @maintenance;
+  location @maintenance {
+    root /var/www/html;
+    rewrite ^(.*)$ /maintenance.html break;
+    internal;
+  }
+
+  set $maintenance false;
+
+  if (-e /var/www/html/maintenance.html) {
+    set $maintenance true;
+  }
+
+  if ($allow_ip ~ allow) {
+    set $maintenance false;
+  }
+
+  if ($maintenance = true) {
+    return 503;
+  }
+}

--- a/ikatodon/ansible/roles/nginx/templates/site.conf.j2
+++ b/ikatodon/ansible/roles/nginx/templates/site.conf.j2
@@ -1,6 +1,9 @@
 {# nginx-audit.md の棚卸しに基づく修正を反映したテンプレート。
    現行設定との差分:
-   - server_name default_server; の誤指定を listen 80 default_server; に修正 (2.1・2.2)
+   - server_name default_server; の誤指定を実ホスト名 (ikatodon_server_name) へ修正
+     (2.1・2.2)。default_server 自体は sites-enabled/default (Debian 既定 vhost) に
+     既に付いているため、ここへは付けない。両方に付けると nginx -t が
+     "a duplicate default server" で失敗する
    - upstream ikatodon_web / ikatodon_streaming 経由にし、peer fallback を導入 (2.9)
    - error_page を相対 URI に統一 (2.6)
    - ssl_protocols を TLSv1.2 TLSv1.3 に、cipher を Mozilla Intermediate 相当に更新 (2.7)
@@ -31,8 +34,8 @@ geo $allow_ip {
 }
 
 server {
-  listen 80 default_server;
-  listen [::]:80 default_server;
+  listen 80;
+  listen [::]:80;
   server_name {{ ikatodon_server_name }};
   root {{ mastodon_dir }}/public;
 

--- a/ikatodon/ansible/roles/nginx/templates/upstream-drain.conf.j2
+++ b/ikatodon/ansible/roles/nginx/templates/upstream-drain.conf.j2
@@ -1,0 +1,12 @@
+{# drain 中。自ホストを down にし、隣サーバーへ全量流す。
+   streaming の WebSocket は再接続が発生する (構造上ゼロにできない)。 #}
+upstream ikatodon_web {
+  server 127.0.0.1:3000 down;
+  server {{ ikatodon_peer_private_ip }}:3000;
+}
+
+upstream ikatodon_streaming {
+  least_conn;
+  server 127.0.0.1:4000 down;
+  server {{ ikatodon_peer_private_ip }}:4000;
+}

--- a/ikatodon/ansible/roles/nginx/templates/upstream-normal.conf.j2
+++ b/ikatodon/ansible/roles/nginx/templates/upstream-normal.conf.j2
@@ -1,0 +1,11 @@
+{# 通常時。自ホストを優先し、自ホストが落ちたときだけ隣サーバー (backup) へ流す。 #}
+upstream ikatodon_web {
+  server 127.0.0.1:3000 max_fails=2 fail_timeout=5s;
+  server {{ ikatodon_peer_private_ip }}:3000 backup;
+}
+
+upstream ikatodon_streaming {
+  least_conn;
+  server 127.0.0.1:4000 max_fails=2 fail_timeout=5s;
+  server {{ ikatodon_peer_private_ip }}:4000 backup;
+}


### PR DESCRIPTION
issue #876 のデプロイ自動化 (4/5)。#895 の上に積む。

nginx-audit.md の棚卸しに基づく修正（HTTP→HTTPS リダイレクト修復、応答のない acme-challenge IP の除外、test vhost 削除、TLS 1.2/1.3 + Mozilla Intermediate cipher、error_page の相対 URI 化）を反映した nginx role を追加し、`upstream ikatodon_web` / `upstream ikatodon_streaming` による peer fallback を導入した。

デプロイ playbook は drain（自ホストを upstream から外す）→ up -d → 3点ヘルスチェック（web `/health`・streaming `/api/v1/streaming/health`・sidekiq running）→ undrain の順に1台ずつ処理する。undrain は必ず実行し、drain したまま終了する経路を作らない。

migration は pre（`SKIP_POST_DEPLOYMENT_MIGRATIONS=true`）→ 全台入替 → post の順で実行する。要否は GitHub Actions 側で `db/migrate`・`db/post_migrate` の差分から判定し、2台の稼働バージョンが食い違っている場合は中断する（前回のデプロイが中途半端に終わっている可能性があるため）。

dry_run オプションを追加し、checkout・override 配布・`.env.production` 配布・pull までで打ち切れるようにした。nginx 設定の適用は独立したワークフロー (ikatodon-nginx.yml) とし、`--check --diff` でのドライランをデフォルトにしてある。

HSTS の重複解消（nginx-audit.md 2.5）はアプリ側の設定確認が必要なため今回は見送り、現状の値を維持した。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered option to safely preview deployments without applying changes.
  * Added a dedicated workflow for validating and applying Nginx configuration.
  * Added maintenance-mode controls with configurable access allowlisting.
  * Added traffic draining and restoration during deployments to reduce disruption.
* **Bug Fixes**
  * Improved deployment safety by detecting host version mismatches and validating service health.
  * Added migration checks and coordinated migration handling for deployments and rollbacks.
* **Documentation**
  * Clarified deployment, rollback, dry-run, and configuration validation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->